### PR TITLE
add response body to withdraw enrollment request

### DIFF
--- a/apps/lti_edu/api.py
+++ b/apps/lti_edu/api.py
@@ -52,7 +52,7 @@ class StudentEnrollmentList(BaseEntityListView):
             return Response(data='Awarded enrollments cannot be withdrawn', status=403)
         if request.user == enrollment.user:
             enrollment.delete()
-            return Response(status=200)
+            return Response(data='Enrollment successfully withdrawn', status=200)
         else:
             return Response(data='Users can only withdraw their own enrollments', status=403)
 


### PR DESCRIPTION
The withdraw enrollment request returns a 200 status with no body. For
clarity it should either return a 204 or a 200 with a reponse body.