### PR TITLE
fix: Make payload for verification request compatible with ssi-agent

### DIFF
--- a/apps/ob3/api.py
+++ b/apps/ob3/api.py
@@ -30,6 +30,7 @@ class CredentialsView(APIView):
         issuer = badgeclass.issuer
         request_data = {
             "subjectId": subject_id,
+            "credentialConfigurationId": "w3c_vc_credential",
             "credential": {
                 "issuer": {
                     "id": f"{UI_URL}/public/issuers/{issuer.entity_id}",
@@ -39,7 +40,6 @@ class CredentialsView(APIView):
                     "name": issuer.name_english
                 },
                 "credentialSubject": {
-                    "id": "",
                     "type": [
                         "AchievementSubject"
                     ],


### PR DESCRIPTION
Impierce SSI-agent requires an additional `credentialConfigurationId` field that must be set according to an ID provided in the config. We use an example config with w3c_vc_credential.

The additional Id field is no longer allowed and caused the server to raise an error when deserializing the subject payload.