### PR TITLE
fix: Add a type:image to the image payload in our credential request.

### DIFF
--- a/apps/ob3/api.py
+++ b/apps/ob3/api.py
@@ -53,6 +53,7 @@ class CredentialsView(APIView):
                         "description": badgeclass.description,
                         "name": badgeclass.name,
                         "image": {
+                            "type":"Image",
                             "id": badgeclass.image_url()
                         }
                     }


### PR DESCRIPTION
Somehow the ssi-agent requires this, and flunks when we don't provide it.