### PR TITLE
Dockerize the server and its supporting services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ AppleDouble
 *.sqlite*
 *.sass-cache
 env_vars.sh
+.env
+.env.*
 staticfiles*
 !staticfiles.py
 mediafiles/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# Use the official Python image from the Docker Hub
+FROM python:3.8
+
+# Install system dependencies for cairo and MySQL client
+RUN apt-get update && apt-get install -y \
+    libcairo2-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Make the locale en_US.UTF-8 available which is needed for mysql client
+RUN apt-get update && apt-get install -y locales \
+    && locale-gen en_US.UTF-8 && dpkg-reconfigure locales \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the current directory contents into the container at /app
+COPY . /app
+
+# Install any needed packages specified in requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Make port 8000 available to the world outside this container
+EXPOSE 8000
+
+# Run the specified command within the container
+CMD ["sh", "/docker/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -26,6 +26,49 @@ Read more on [edubadges.nl](https://www.surf.nl/en/edubadges-national-approach-t
 Badgr was developed by [Concentric Sky](https://concentricsky.com), starting in 2015 to serve as an open source reference implementation of the Open Badges Specification. It provides functionality to issue portable, verifiable Open Badges as well as to allow users to manage badges they have been awarded by any issuer that uses this open data standard. Since 2015, Badgr has grown to be used by hundreds of educational institutions and other people and organizations worldwide. See [Project Homepage](https://badgr.org) for more details about contributing to and integrating with Badgr.
 
 # Edubadges installation instructions
+
+Either choose local development, where everything is installed and running on the local machine. Or choose Docker
+
+## How to use Docker and docker compose.
+
+Prerequisites: 
+* Docker and Docker compose (current docker desktop ships them by default)
+
+### Prepare a dotenv file for running docker commands
+
+Make an .env.docker file with a few secrets. See docker-compose for the ENV vars that are referenced from
+the shell running docker compose commands. At time of writing these are:
+
+```
+BADGR_DB_PASSWORD=local-secret-only
+OIDC_RS_SECRET=
+EDU_ID_SECRET=
+SURF_CONEXT_SECRET=
+```
+
+The BADGR_DB_PASSWORD isn't critical as it's only used within the docker-compose cluster. The
+other secrets should be asked at a colleague as they are required to communicate with auth, profile
+and sso services.
+
+Load these in the shell where you run docker-compse. E.g by sourcing it, or with a tool like dotenv.
+
+### Run docker compose up
+
+This will build and run any docker images in the foreground. Ctrl-C to exit.
+Add the `-d` flag to run in the background.
+
+```
+docker compose up
+```
+
+This will:
+* Start Mysql
+* Start memcached
+* Build a container that can run and host the app.
+* Run that container and mount the local source code in the app.
+
+TODO: can we run the server so it reboots on detecting changes instead of having to reboot the image?
+
 ## How to get started on your local development environment.
 Prerequisites:
 

--- a/apps/issuer/migrations/0043_auto_20180614_0949.py
+++ b/apps/issuer/migrations/0043_auto_20180614_0949.py
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='badgeinstance',
             name='recipient_identifier',
-            field=models.EmailField(db_index=True, max_length=768),
+            field=models.EmailField(db_index=True, max_length=512),
         ),
         migrations.AlterIndexTogether(
             name='badgeinstance',

--- a/apps/issuer/migrations/0044_auto_20180713_0658.py
+++ b/apps/issuer/migrations/0044_auto_20180713_0658.py
@@ -16,6 +16,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='badgeinstance',
             name='recipient_identifier',
-            field=models.EmailField(db_index=True, max_length=768),
+            field=models.EmailField(db_index=True, max_length=512),
         ),
     ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,81 @@
+---
+services:
+  badgr:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: badgr
+    command: "./docker/entrypoint.sh"
+    volumes:
+      - .:/app
+    working_dir: /app
+    environment:
+      # Be sure to set BADGR_DB_PASSWORD when running docker-compose
+      - ACCOUNT_SALT=secret
+      - ALLOW_SEEDS=1
+      - BADGR_APP_ID=1
+      - BADGR_DB_HOST=db
+      - BADGR_DB_NAME=badgr
+      - BADGR_DB_PASSWORD=${BADGR_DB_PASSWORD}
+      - BADGR_DB_PORT=3306
+      - BADGR_DB_USER=badgr
+      - DEBUG=1
+      - DEFAULT_DOMAIN=http://0.0.0.0:8000
+      - DEFAULT_FROM_EMAIL=noreply@surf.nl
+      - DOMAIN=0.0.0.0:8000
+      - EDUID_PROVIDER_URL=https://connect.test.surfconext.nl/oidc
+      - EDUID_REGISTRATION_URL=https://login.test.eduid.nl/register
+      - EDU_ID_CLIENT=edubadges
+      - EDU_ID_SECRET=${EDU_ID_SECRET}
+      - EMAIL_HOST=mailhog
+      - EMAIL_PORT=1025
+      - LTI_FRONTEND_URL=localhost
+      - MEMCACHED_HOST=memcached
+      - MEMCACHED_PORT=11211
+      - OIDC_RS_ENTITY_ID=test.edubadges.rs.nl
+      - OIDC_RS_SECRET=${OIDC_RS_SECRET}
+      - ROOT_INFO_SECRET_KEY=secret
+      - SITE_ID=1
+      - SUPERUSER_EMAIL=superuser@example.com
+      - SUPERUSER_NAME=superuser
+      - SUPERUSER_PWD=secert
+      - SURF_CONEXT_CLIENT=test.edubadges.nl
+      - SURF_CONEXT_CLIENT=www.edubadges.nl
+      - SURF_CONEXT_SECRET=${SURF_CONEXT_SECRET}
+      - TIME_STAMPED_OPEN_BADGES_BASE_URL=http://0.0.0.0:8000/
+      - UI_URL=http://0.0.0.0:8080
+      - UNSUBSCRIBE_SECRET_KEY=secret
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - "8000:8000"
+      
+  db:
+    image: mysql:8.4
+    container_name: badgr_mysql_db
+    environment:
+      MYSQL_ROOT_PASSWORD: ${BADGR_DB_PASSWORD}
+      MYSQL_DATABASE: badgr
+      MYSQL_USER: badgr
+      MYSQL_PASSWORD: ${BADGR_DB_PASSWORD}
+    ports:
+      - "3306:3306"
+    # Health check for MySQL
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-prootpassword"]
+      interval: 10s
+      retries: 5
+      start_period: 30s
+      timeout: 10s
+
+  mailhog:
+    image: mailhog/mailhog
+    container_name: mailhog
+    ports:
+      - "1025:1025"
+      - "8025:8025"
+
+  memcached:
+    image: memcached:latest
+    container_name: memcached

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+set -x
+
+# Run migrations
+echo "Running migrations"
+python ./manage.py migrate
+
+# Reset (-c) and Seed the database
+echo "Seeding the database"
+python ./manage.py seed -c
+
+# Run the server
+echo "Starting the server"
+# python -m http.server 8000
+python ./manage.py runserver --verbosity 2 0.0.0.0:8000

--- a/env_vars.sh.example
+++ b/env_vars.sh.example
@@ -33,5 +33,5 @@ export UI_URL="http://localhost:4000"
 export UNSUBSCRIBE_SECRET_KEY="secret"
 export LC_ALL="en_US.UTF-8"
 export LANG="en_US.UTF-8"
-export MEMCACHED_HOST="127.0.0.1
+export MEMCACHED_HOST="127.0.0.1"
 export MEMCACHED_PORT="11211"


### PR DESCRIPTION
This is a PR to discuss the solution to the issue with migrations.

It is unclear why the migrations keep failing, but they won't pass if the `recipient_identifier` is 
a varchar(712). At least not in the dockerized version of mysql 8.4. It fails on creating the
index, as the index is larger than 3072.

The database is utf8, and collation is correct.

When we set this column to be only 512 long, as it is at the end of running all migrations anyway,
the index can be created.

The failure is:

```
  Applying issuer.0043_auto_20180614_0949... OK
  Applying issuer.0044_auto_20180713_0658...Traceback (most recent call last):
  ...
MySQLdb.OperationalError: (1071, 'Specified key was too long; max key length is 3072 bytes')

```

This PR proposes two alternative solutions to this:

1. Remove the index creation from issuer.0043_auto_20180614_0949 and add it in a new migration at the end
2. Modify existing migrations and ensure the recipient_identifier is varchar(512).

The option 1 was reverted and can only be witnessed in the git history of this PR. It has a severe
downside: production builds, and other builds will run this new migration, but
will fail, as the index exsists. Neither MySQL nor django migrations have a
mechanism to "CREATE INDEX .. IF NOT EXISTS" like postgres or mariadb do.

Option 2 has downside that it alters migrations that have already been applied. Which is normally
a bad practice.


- **fix: Fix unclosed quote in example env var file**
- **fix: Add compound index when the indexed columns have the right size**
- **feat: Docker compose with required services**
- **Revert "fix: Add compound index when the indexed columns have the right size"**
- **fix: Allow migrations to create indexes that are guaranteed to be under 3072**
