### PR TITLE
Feature/second agent

### DIFF
--- a/apps/mainsite/seeds/01_setup.py
+++ b/apps/mainsite/seeds/01_setup.py
@@ -73,6 +73,8 @@ surf_net_institution, _ = Institution.objects.get_or_create(name_english=SURF_IN
                                                             description_dutch=SURF_INSTITUTION_NAME,
                                                             image_english="uploads/issuers/surf.png",
                                                             image_dutch="uploads/issuers/surf.png",
+                                                            ob3_ssi_agent_enabled=True,
+                                                            micro_credentials_enabled=True,
                                                             )
 # Terms general
 terms_service_agreement_student, _ = Terms.objects.get_or_create(institution=None, terms_type=Terms.TYPE_SERVICE_AGREEMENT_STUDENT)

--- a/apps/mainsite/settings.py
+++ b/apps/mainsite/settings.py
@@ -301,9 +301,19 @@ LOGGING = {
             'interval': 1,
             'backupCount': 30*24,  # 30 days times 24 hours
             'filename': os.path.join(LOGS_DIR, 'badgr_debug.log')
-        }
+        },
+        'badgr_debug_console': {
+            'level': 'DEBUG',
+            'formatter': 'default',
+            'filters': ['require_debug_true'],
+            'class': 'logging.StreamHandler'
+        },
     },
     'loggers': {
+        'django': {
+            'handlers': ['badgr_debug_console'],
+            'propagate': True,
+        },
         'django.request': {
             'handlers': ['mail_admins'],
             'level': 'ERROR',
@@ -336,6 +346,11 @@ LOGGING = {
             '()': 'mainsite.formatters.JsonFormatter',
             'format': '%(asctime)s',
             'datefmt': '%Y-%m-%dT%H:%M:%S%z',
+        }
+    },
+    'filters': {
+        'require_debug_true': {
+            '()': 'django.utils.log.RequireDebugTrue',
         }
     },
 }

--- a/apps/mainsite/settings.py
+++ b/apps/mainsite/settings.py
@@ -201,7 +201,9 @@ EDUID_API_BASE_URL = os.environ.get('EDUID_API_BASE_URL', 'https://login.test.ed
 EDUID_IDENTIFIER = os.environ.get('EDUID_IDENTIFIER', 'eduid')
 
 DIRECT_AWARDS_DELETION_THRESHOLD_DAYS = int(os.environ.get('DIRECT_AWARDS_DELETION_THRESHOLD_DAYS', 30))
-OB3_API_URL = os.environ.get('OB3_API_URL', '')
+OB3_AGENT_URL_SPHEREON = os.environ.get('OB3_AGENT_URL_SPHEREON', '')
+OB3_AGENT_AUTHZ_TOKEN_SPHEREON = os.environ.get('OB3_AGENT_AUTHZ_TOKEN_SPHEREON', '')
+OB3_AGENT_URL_UNIME = os.environ.get('OB3_AGENT_URL_UNIME', '')
 
 # If you have an informational front page outside the Django site that can link back to '/login', specify it here
 ROOT_INFO_REDIRECT = '/login'
@@ -603,5 +605,5 @@ SPECTACULAR_SETTINGS = {
 
 # settings.py
 API_PROXY = {
-    'HOST': OB3_API_URL
+    'HOST': OB3_AGENT_URL_UNIME
 }

--- a/apps/mainsite/settings.py
+++ b/apps/mainsite/settings.py
@@ -201,7 +201,7 @@ EDUID_API_BASE_URL = os.environ.get('EDUID_API_BASE_URL', 'https://login.test.ed
 EDUID_IDENTIFIER = os.environ.get('EDUID_IDENTIFIER', 'eduid')
 
 DIRECT_AWARDS_DELETION_THRESHOLD_DAYS = int(os.environ.get('DIRECT_AWARDS_DELETION_THRESHOLD_DAYS', 30))
-OB3_API_URL = os.environ.get('OB3_API_URL', 'http://poc4.educredentials.eu:3033')
+OB3_API_URL = os.environ.get('OB3_API_URL', '')
 
 # If you have an informational front page outside the Django site that can link back to '/login', specify it here
 ROOT_INFO_REDIRECT = '/login'

--- a/apps/ob3/api.py
+++ b/apps/ob3/api.py
@@ -12,7 +12,6 @@ from rest_framework.views import APIView
 from issuer.models import BadgeInstance
 from mainsite.settings import OB3_API_URL, UI_URL
 
-
 class CredentialsView(APIView):
     permission_classes = (permissions.AllowAny,)
     http_method_names = ['post']
@@ -26,13 +25,7 @@ class CredentialsView(APIView):
 
         self.__issue_badge(badge_instance)
         credential_offer = self.__get_offer(offer_id)
-
-        img = qrcode.make(credential_offer)
-
-        buffered = BytesIO()
-        img.save(buffered, format="PNG")
-        img_str = base64.b64encode(buffered.getvalue()).decode()
-
+        img_str = self.__qr_code(credential_offer)
         return Response({"qr_code_base64": img_str}, status=status.HTTP_201_CREATED)
 
     def __badge_instance(self, badge_id, user):
@@ -92,3 +85,9 @@ class CredentialsView(APIView):
                 }
             }
         }
+
+    def __qr_code(self, credential_offer):
+        img = qrcode.make(credential_offer)
+        buffered = BytesIO()
+        img.save(buffered, format="PNG")
+        return base64.b64encode(buffered.getvalue()).decode()

--- a/apps/ob3/api.py
+++ b/apps/ob3/api.py
@@ -2,15 +2,17 @@ import base64
 import uuid
 from io import BytesIO
 
+import json
 import qrcode
 import requests
 from django.http import Http404
+from django.core.exceptions import BadRequest
 from rest_framework import status, permissions
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from issuer.models import BadgeInstance
-from mainsite.settings import OB3_API_URL, UI_URL
+from mainsite.settings import OB3_AGENT_URL_SPHEREON, OB3_AGENT_AUTHZ_TOKEN_SPHEREON, OB3_AGENT_URL_UNIME, UI_URL
 
 class CredentialsView(APIView):
     permission_classes = (permissions.AllowAny,)
@@ -19,13 +21,25 @@ class CredentialsView(APIView):
     def post(self, request, **kwargs):
         offer_id = str(uuid.uuid4())
         badge_id = request.data.get('badge_id')
+        variant = request.data.get('variant')
 
         badge_instance = self.__badge_instance(badge_id, request.user)
-        request_data = self.__request_data(offer_id, badge_instance)
+        credential = self.__credential(offer_id, badge_instance)
 
-        self.__issue_badge(badge_instance)
-        credential_offer = self.__get_offer(offer_id)
-        img_str = self.__qr_code(credential_offer)
+        if variant == 'sphereon':
+            open_id_credential_offer = self.__issue_sphereon_badge(credential)
+            # We get back a json object that wraps an openid-credential-offer:// uri
+            # Inside this, is a a parameter credential_offer_uri that contains the actual offer uri
+            # Which we can fetch to get the offer
+            offer = json.loads(open_id_credential_offer).get('uri')
+
+        elif variant == 'unime':
+           self.__issue_unime_badge(credential)
+           offer = self.__get_offer(offer_id)
+        else:
+            raise Http404 # Should best be a 400 error, but that seems hard in Django?
+
+        img_str = self.__qr_code(offer)
         return Response({"qr_code_base64": img_str}, status=status.HTTP_201_CREATED)
 
     def __badge_instance(self, badge_id, user):
@@ -34,21 +48,42 @@ class CredentialsView(APIView):
         except BadgeInstance.DoesNotExist:
             raise Http404
 
-    def __issue_badge(self, badge_instance):
-        requests.post(json=request_data,
-                      url=f"{OB3_API_URL}/v0/credentials",
+    def __issue_sphereon_badge(self, credential):
+        credential.update({"credentialConfigurationId": "OpenBadgeCredential"})
+        offer_request_body = {
+                "credentials": ["OpenBadgeCredential"],
+                "grants": {
+                    "urn:ietf:params:oauth:grant-type:pre-authorized_code": {
+                        "pre-authorized_code": "This-is-sent-via-SMS",
+                        "user_pin_required": False
+                        }
+                    },
+                "CredentialDataSupplierInput": credential
+                }
+        resp = requests.post(json=offer_request_body,
+                      url=f"{OB3_AGENT_URL_SPHEREON}/edubadges/api/create-offer",
+                      headers={'Accept': 'application/json',
+                               "Authorization": f"Bearer {OB3_AGENT_AUTHZ_TOKEN_SPHEREON}"})
+        if resp.status_code != 200:
+            msg = f"Failed to issue badge:\n\tcode: {resp.status_code}\n\tcontent:\n {resp.text}"
+            raise BadRequest(msg)
+
+        return resp.text
+
+    def __issue_unime_badge(self, credential):
+        requests.post(json=credential,
+                      url=f"{OB3_AGENT_URL_UNIME}/v0/credentials",
                       headers={'Accept': 'application/json'})
 
     def __get_offer(self, offer_id):
         offer_id = {"offerId": offer_id}
         response = requests.post(json=offer_id,
-                                 url=f"{OB3_API_URL}/v0/offers",
+                                 url=f"{OB3_AGENT_URL_UNIME}/v0/offers",
                                  headers={'Accept': 'application/json'})
 
         return response.text
 
-
-    def __request_data(self, offer_id, badge_instance):
+    def __credential(self, offer_id, badge_instance):
         badgeclass = badge_instance.badgeclass
         criteria = badgeclass.criteria_text
         issuer = badgeclass.issuer

--- a/apps/ob3/api.py
+++ b/apps/ob3/api.py
@@ -18,16 +18,48 @@ class CredentialsView(APIView):
     http_method_names = ['post']
 
     def post(self, request, **kwargs):
+        offer_id = str(uuid.uuid4())
         badge_id = request.data.get('badge_id')
-        badge_instance = BadgeInstance.objects.get(id=badge_id)
-        if badge_instance.user != request.user:
+
+        badge_instance = self.__badge_instance(badge_id, request.user)
+        request_data = self.__request_data(offer_id, badge_instance)
+
+        self.__issue_badge(badge_instance)
+        credential_offer = self.__get_offer(offer_id)
+
+        img = qrcode.make(credential_offer)
+
+        buffered = BytesIO()
+        img.save(buffered, format="PNG")
+        img_str = base64.b64encode(buffered.getvalue()).decode()
+
+        return Response({"qr_code_base64": img_str}, status=status.HTTP_201_CREATED)
+
+    def __badge_instance(self, badge_id, user):
+        try:
+            return BadgeInstance.objects.get(id=badge_id, user=user)
+        except BadgeInstance.DoesNotExist:
             raise Http404
 
+    def __issue_badge(self, badge_instance):
+        requests.post(json=request_data,
+                      url=f"{OB3_API_URL}/v0/credentials",
+                      headers={'Accept': 'application/json'})
+
+    def __get_offer(self, offer_id):
+        offer_id = {"offerId": offer_id}
+        response = requests.post(json=offer_id,
+                                 url=f"{OB3_API_URL}/v0/offers",
+                                 headers={'Accept': 'application/json'})
+
+        return response.text
+
+
+    def __request_data(self, offer_id, badge_instance):
         badgeclass = badge_instance.badgeclass
         criteria = badgeclass.criteria_text
-        offer_id = str(uuid.uuid4())
         issuer = badgeclass.issuer
-        request_data = {
+        return {
             "offerId": offer_id,
             "credentialConfigurationId": "openbadge_credential",
             "credential": {
@@ -60,20 +92,3 @@ class CredentialsView(APIView):
                 }
             }
         }
-        requests.post(json=request_data,
-                      url=f"{OB3_API_URL}/v0/credentials",
-                      headers={'Accept': 'application/json'})
-
-        offer_id = {"offerId": offer_id}
-        response = requests.post(json=offer_id,
-                                 url=f"{OB3_API_URL}/v0/offers",
-                                 headers={'Accept': 'application/json'})
-
-        credential_offer = response.text
-        img = qrcode.make(credential_offer)
-
-        buffered = BytesIO()
-        img.save(buffered, format="PNG")
-        img_str = base64.b64encode(buffered.getvalue()).decode()
-
-        return Response({"qr_code_base64": img_str}, status=status.HTTP_201_CREATED)

--- a/apps/ob3/api.py
+++ b/apps/ob3/api.py
@@ -65,7 +65,7 @@ class CredentialsView(APIView):
                     "user_pin_required": False
                 }
             },
-            "CredentialDataSupplierInput": credential
+            "credentialDataSupplierInput": credential
         }
         resp = requests.post(json=offer_request_body,
                       url=f"{OB3_AGENT_URL_SPHEREON}/edubadges/api/create-offer",

--- a/apps/ob3/api.py
+++ b/apps/ob3/api.py
@@ -6,7 +6,7 @@ import json
 import qrcode
 import requests
 from django.http import Http404
-from django.core.exceptions import BadRequest
+from django.core.exceptions import BadRequest, ObjectDoesNotExist
 from rest_framework import status, permissions
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -45,7 +45,7 @@ class CredentialsView(APIView):
     def __badge_instance(self, badge_id, user):
         try:
             return BadgeInstance.objects.get(id=badge_id, user=user)
-        except BadgeInstance.DoesNotExist:
+        except ObjectDoesNotExist:
             raise Http404
 
     def __issue_sphereon_badge(self, credential):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - ACCOUNT_SALT=secret
       - ALLOW_SEEDS=1
       - BADGR_APP_ID=1
-      - BADGR_DB_HOST=db
+      - BADGR_DB_HOST=badgr_mysql_db
       - BADGR_DB_NAME=badgr
       - BADGR_DB_PASSWORD=${BADGR_DB_PASSWORD}
       - BADGR_DB_PORT=3306
@@ -48,6 +48,9 @@ services:
       - OB3_AGENT_URL_UNIME=https://agent.poc9.eduwallet.nl
       - OB3_AGENT_URL_SPHEREON=http://veramo-agent:3000
       - OB3_AGENT_AUTHZ_TOKEN_SPHEREON=${OB3_AGENT_AUTHZ_TOKEN_SPHEREON}
+    networks:
+      - shared-network
+      - edubadges-server
     depends_on:
       db:
         condition: service_healthy
@@ -71,6 +74,8 @@ services:
       retries: 5
       start_period: 30s
       timeout: 10s
+    networks:
+      - edubadges-server
 
   mailhog:
     image: mailhog/mailhog
@@ -78,7 +83,17 @@ services:
     ports:
       - "1025:1025"
       - "8025:8025"
+    networks:
+      - edubadges-server
 
   memcached:
     image: memcached:latest
     container_name: memcached
+    networks:
+      - edubadges-server
+
+networks:
+  shared-network:
+    external: true
+  edubadges-server:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,9 @@ services:
       - TIME_STAMPED_OPEN_BADGES_BASE_URL=http://0.0.0.0:8000/
       - UI_URL=http://0.0.0.0:8080
       - UNSUBSCRIBE_SECRET_KEY=secret
-      - OB3_API_URL=https://agent.poc9.eduwallet.nl
+      - OB3_AGENT_URL_UNIME=https://agent.poc9.eduwallet.nl
+      - OB3_AGENT_URL_SPHEREON=http://veramo-agent:3000
+      - OB3_AGENT_AUTHZ_TOKEN_SPHEREON=${OB3_AGENT_AUTHZ_TOKEN_SPHEREON}
     depends_on:
       db:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
       - TIME_STAMPED_OPEN_BADGES_BASE_URL=http://0.0.0.0:8000/
       - UI_URL=http://0.0.0.0:8080
       - UNSUBSCRIBE_SECRET_KEY=secret
+      - OB3_API_URL=https://agent.poc9.eduwallet.nl
     depends_on:
       db:
         condition: service_healthy

--- a/env_vars.sh.example
+++ b/env_vars.sh.example
@@ -35,3 +35,8 @@ export LC_ALL="en_US.UTF-8"
 export LANG="en_US.UTF-8"
 export MEMCACHED_HOST="127.0.0.1"
 export MEMCACHED_PORT="11211"
+
+# Only needed when wallet import is used
+export OB3_AGENT_URL_SPHEREON="http://localhost:5000"
+export OB3_AGENT_AUTHZ_TOKEN_SPHEREON="s3cr3t"
+export OB3_AGENT_URL_UNIME="http://localhost:6000"


### PR DESCRIPTION
This adds veramo agent next to unime-core (impierce-agent) for the backend.

We need to change some ENV vars on the server for this:

- OB3_AGENT_URL_UNIME=https://agent.poc9.eduwallet.nl
- OB3_AGENT_URL_SPHEREON=http://agent.poc4.eduwallet.nl
- OB3_AGENT_AUTHZ_TOKEN_SPHEREON=`KZrxxxxxxxxxxxxx`


What was `OB3_API_URL` now is  `OB3_AGENT_URL_UNIME`


**NOTE:** This PR was made over PR #144 so we cannot merge this one until that other one lands first.