### PR TITLE
feat: Upgrade python from 3.8 to 3.9 in our app Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official Python image from the Docker Hub
-FROM python:3.8
+FROM python:3.9
 
 # Install system dependencies for cairo and MySQL client
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
We used an EOL python version in the Docker image. Bumped to 3.9.

>  Zag toevallig nog dat python 3.8 end of life ( https://endoflife.date/python ) is sinds deze maand (dus ook geen security updates meer). In de Ansible scripts wordt al 3.9 gebruikt. Maar in de dockerfile van de server zie ik nog 3.8: https://github.com/edubadges/edubadges-server/blob/develop/Dockerfile Misschien handig dit te updaten? De README van de server moet ook nog geupdate worden