### PR TITLE
Feature/offer as json

### DIFF
--- a/apps/ob3/api.py
+++ b/apps/ob3/api.py
@@ -21,7 +21,9 @@ class CredentialsView(APIView):
     permission_classes = (permissions.AllowAny,)
     http_method_names = ['post']
 
-    def post(self, request, **kwargs):
+    def post(self, request, **_kwargs):
+        _ = _kwargs # explicitly ignore kwargs
+
         offer_id = str(uuid.uuid4())
         badge_id = request.data.get('badge_id')
         variant = request.data.get('variant')

--- a/apps/ob3/api.py
+++ b/apps/ob3/api.py
@@ -1,9 +1,6 @@
-import base64
 import uuid
-from io import BytesIO
 
 import json
-import qrcode
 import requests
 import logging
 from django.http import Http404
@@ -49,8 +46,7 @@ class CredentialsView(APIView):
         else:
             raise Http404 # Should best be a 400 error, but that seems hard in Django?
 
-        img_str = self.__qr_code(offer)
-        return Response({"qr_code_base64": img_str}, status=status.HTTP_201_CREATED)
+        return Response({"offer": offer}, status=status.HTTP_201_CREATED)
 
     def __badge_instance(self, badge_id, user):
         try:
@@ -135,9 +131,3 @@ class CredentialsView(APIView):
                 }
             }
         }
-
-    def __qr_code(self, credential_offer):
-        img = qrcode.make(credential_offer)
-        buffered = BytesIO()
-        img.save(buffered, format="PNG")
-        return base64.b64encode(buffered.getvalue()).decode()

--- a/requirements.txt
+++ b/requirements.txt
@@ -134,4 +134,3 @@ pycryptodome==3.19.1
 
 #https://github.com/aiselis/django-api-proxy
 django-api-proxy==0.1.1
-qrcode==7.4.2


### PR DESCRIPTION
This generates the QR code in the client, rather than the server side.

For simplicity, this PR depends on the matching PR in the edubadges-ui (https://github.com/edubadges/edubadges-ui/pull/134) to be merged and deployed simultaneously-ish. If this is unwanted, let me know, and I'll add temporary logic to detect if the server sends JSON or a base64 load and use either of these. That would allow us to first merge and deploy this one. and then, once settled, merge and deploy the server version.

This pull request includes several changes to the `apps/ob3/api.py` file, focusing on simplifying the code and removing unnecessary dependencies. The most important changes include removing the QR code generation functionality, simplifying the `post` method, and cleaning up imports.

Code simplification and cleanup:

* Removed unused imports `base64`, `BytesIO`, and `qrcode` from `apps/ob3/api.py`.
* Modified the `post` method in `class CredentialsView(APIView)` to explicitly ignore `kwargs`.
* Simplified the response in the `post` method by removing the QR code generation and returning the `offer` directly.
* Removed the `__qr_code` method and its associated QR code generation logic from the `__credential` method.