### PR TITLE
Feature/fuller creds

### DIFF
--- a/apps/mainsite/settings.py
+++ b/apps/mainsite/settings.py
@@ -308,6 +308,7 @@ LOGGING = {
     'loggers': {
         'django': {
             'handlers': ['badgr_debug_console'],
+            'level': 'DEBUG',
             'propagate': True,
         },
         'django.request': {

--- a/apps/ob3/api.py
+++ b/apps/ob3/api.py
@@ -69,10 +69,13 @@ class CredentialsView(APIView):
             },
             "credentialDataSupplierInput": credential
         }
-        resp = requests.post(json=offer_request_body,
-                      url=f"{OB3_AGENT_URL_SPHEREON}/edubadges/api/create-offer",
-                      headers={'Accept': 'application/json',
-                               "Authorization": f"Bearer {OB3_AGENT_AUTHZ_TOKEN_SPHEREON}"})
+        resp = requests.post(
+                timeout=5,
+                url=f"{OB3_AGENT_URL_SPHEREON}/edubadges/api/create-offer",
+                json=offer_request_body,
+                headers={'Accept': 'application/json',
+                         "Authorization": f"Bearer {OB3_AGENT_AUTHZ_TOKEN_SPHEREON}"}
+        )
 
         if resp.status_code >= 400:
             msg = f"Failed to issue badge:\n\tcode: {resp.status_code}\n\tcontent:\n {resp.text}"
@@ -86,16 +89,23 @@ class CredentialsView(APIView):
         return json_resp.get('uri')
 
     def __issue_unime_badge(self, credential):
-        resp = requests.post(json=credential,
-                      url=f"{OB3_AGENT_URL_UNIME}/v0/credentials",
-                      headers={'Accept': 'application/json'})
+        resp = requests.post(
+                timeout=5,
+                json=credential,
+                url=f"{OB3_AGENT_URL_UNIME}/v0/credentials",
+                headers={'Accept': 'application/json'}
+        )
 
         if resp.status_code >= 400:
             msg = f"Failed to issue badge:\n\tcode: {resp.status_code}\n\tcontent:\n {resp.text}"
             raise BadRequest(msg)
 
     def __get_unime_offer(self, offer_id):
-        response = requests.post(json= { "offerId": offer_id },
-                                 url=f"{OB3_AGENT_URL_UNIME}/v0/offers",
-                                 headers={'Accept': 'application/json'})
+        response = requests.post(
+                timeout=5,
+                url=f"{OB3_AGENT_URL_UNIME}/v0/offers",
+                json= { "offerId": offer_id },
+                headers={'Accept': 'application/json'}
+        )
+
         return response.text

--- a/apps/ob3/api.py
+++ b/apps/ob3/api.py
@@ -15,7 +15,7 @@ from mainsite.settings import OB3_AGENT_URL_SPHEREON, OB3_AGENT_AUTHZ_TOKEN_SPHE
 from .serializers import EduCredentialSerializer
 from .models import EduCredential
 
-logger = logging.getLogger('Badgr.Debug')
+logger = logging.getLogger('django')
 
 class CredentialsView(APIView):
     permission_classes = (permissions.AllowAny,)

--- a/apps/ob3/api.py
+++ b/apps/ob3/api.py
@@ -12,8 +12,8 @@ from pprint import pformat
 
 from issuer.models import BadgeInstance
 from mainsite.settings import OB3_AGENT_URL_SPHEREON, OB3_AGENT_AUTHZ_TOKEN_SPHEREON, OB3_AGENT_URL_UNIME
-from .serializers import EduCredentialSerializer
-from .models import EduCredential
+from .serializers import OfferRequestSerializer
+from .models import OfferRequest
 
 logger = logging.getLogger('django')
 
@@ -34,8 +34,8 @@ class CredentialsView(APIView):
             'sphereon': "OpenBadgeCredential",
             'unime': "openbadge_credential"
         }.get(variant) 
-        credential = EduCredential(offer_id, credential_configuration_id, badge_instance)
-        serializer = EduCredentialSerializer(credential)
+        credential = OfferRequest(offer_id, credential_configuration_id, badge_instance)
+        serializer = OfferRequestSerializer(credential)
 
         if variant == 'sphereon':
             offer = self.__issue_sphereon_badge(serializer.data)

--- a/apps/ob3/api.py
+++ b/apps/ob3/api.py
@@ -1,6 +1,5 @@
 import uuid
 
-import json
 import requests
 import logging
 from django.http import Http404
@@ -9,10 +8,14 @@ from rest_framework import status, permissions
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from issuer.models import BadgeInstance
-from mainsite.settings import OB3_AGENT_URL_SPHEREON, OB3_AGENT_AUTHZ_TOKEN_SPHEREON, OB3_AGENT_URL_UNIME, UI_URL
+from pprint import pformat
 
-logger = logging.getLogger(__name__)
+from issuer.models import BadgeInstance
+from mainsite.settings import OB3_AGENT_URL_SPHEREON, OB3_AGENT_AUTHZ_TOKEN_SPHEREON, OB3_AGENT_URL_UNIME
+from .serializers import EduCredentialSerializer
+from .models import EduCredential
+
+logger = logging.getLogger('Badgr.Debug')
 
 class CredentialsView(APIView):
     permission_classes = (permissions.AllowAny,)
@@ -26,25 +29,26 @@ class CredentialsView(APIView):
         variant = request.data.get('variant')
 
         badge_instance = self.__badge_instance(badge_id, request.user)
-        credential = self.__credential(offer_id, badge_instance)
+        logger.debug(f"Badge instance: {pformat(badge_instance.__dict__)}")
+        credential_configuration_id = {
+            'sphereon': "OpenBadgeCredential",
+            'unime': "openbadge_credential"
+        }.get(variant) 
+        credential = EduCredential(offer_id, credential_configuration_id, badge_instance)
+        serializer = EduCredentialSerializer(credential)
 
         if variant == 'sphereon':
-            credential.update({"credentialConfigurationId": "OpenBadgeCredential"})
-            logger.debug(f"Requesting badge w sphereon for {badge_instance.entity_id}")
-            open_id_credential_offer = self.__issue_sphereon_badge(credential)
-            # We get back a json object that wraps an openid-credential-offer:// uri
-            # Inside this, is a a parameter credential_offer_uri that contains the actual offer uri
-            # Which we can fetch to get the offer
-            offer = json.loads(open_id_credential_offer).get('uri')
-
+            offer = self.__issue_sphereon_badge(serializer.data)
+            logger.debug(f"Sphereon offer: {offer}")
         elif variant == 'unime':
-           credential.update({"credentialConfigurationId": "openbadge_credential"})
+            self.__issue_unime_badge(serializer.data)
+            offer = self.__get_unime_offer(offer_id)
+            logger.debug(f"Unime offer: {offer}")
 
-           logger.debug(f"Requesting badge w unime for {badge_instance.entity_id}")
-           self.__issue_unime_badge(credential)
-           offer = self.__get_offer(offer_id)
-        else:
-            raise Http404 # Should best be a 400 error, but that seems hard in Django?
+        offer = self.__issue_sphereon_badge(serializer.data)
+
+        logger.info(f"Issued credential for badge {badge_id} with offer_id {offer_id}")
+        logger.debug(f"Credential: {pformat(serializer.data)}")
 
         return Response({"offer": offer}, status=status.HTTP_201_CREATED)
 
@@ -69,65 +73,29 @@ class CredentialsView(APIView):
                       url=f"{OB3_AGENT_URL_SPHEREON}/edubadges/api/create-offer",
                       headers={'Accept': 'application/json',
                                "Authorization": f"Bearer {OB3_AGENT_AUTHZ_TOKEN_SPHEREON}"})
-        logger.info(f"Sphereon response: {resp.text}")
+
         if resp.status_code >= 400:
             msg = f"Failed to issue badge:\n\tcode: {resp.status_code}\n\tcontent:\n {resp.text}"
             raise BadRequest(msg)
 
-        return resp.text
+
+        # We get back a json object that wraps an openid-credential-offer:// uri
+        # Inside this, is a a parameter credential_offer_uri that contains the actual offer uri
+        # Which we can fetch to get the offer
+        json_resp = resp.json()
+        return json_resp.get('uri')
 
     def __issue_unime_badge(self, credential):
         resp = requests.post(json=credential,
                       url=f"{OB3_AGENT_URL_UNIME}/v0/credentials",
                       headers={'Accept': 'application/json'})
-        logger.debug(f"Unime response: {resp.text}")
 
         if resp.status_code >= 400:
             msg = f"Failed to issue badge:\n\tcode: {resp.status_code}\n\tcontent:\n {resp.text}"
             raise BadRequest(msg)
 
-
-    def __get_offer(self, offer_id):
-        offer_id = {"offerId": offer_id}
-        response = requests.post(json=offer_id,
+    def __get_unime_offer(self, offer_id):
+        response = requests.post(json= { "offerId": offer_id },
                                  url=f"{OB3_AGENT_URL_UNIME}/v0/offers",
                                  headers={'Accept': 'application/json'})
-
         return response.text
-
-    def __credential(self, offer_id, badge_instance):
-        badgeclass = badge_instance.badgeclass
-
-        return {
-            "offerId": offer_id,
-            "credentialConfigurationId": None,
-            "credential": {
-                "issuer": {
-                    "id": f"{UI_URL}/public/issuers/{badgeclass.issuer.entity_id}",
-                    "type": [
-                        "Profile"
-                    ],
-                    "name": badgeclass.issuer.name_english
-                },
-                "credentialSubject": {
-                    "type": [
-                        "AchievementSubject"
-                    ],
-                    "achievement": {
-                        "id": f"{UI_URL}/public/assertions/{badge_instance.entity_id}",
-                        "type": [
-                            "Achievement"
-                        ],
-                        "criteria": {
-                            "narrative": badgeclass.criteria_text
-                        },
-                        "description": badgeclass.description,
-                        "name": badgeclass.name,
-                        "image": {
-                            "type":"Image",
-                            "id": badgeclass.image_url()
-                        }
-                    }
-                }
-            }
-        }

--- a/apps/ob3/models.py
+++ b/apps/ob3/models.py
@@ -1,17 +1,25 @@
 # A plain old Python object (POPO) that represents an educational credential
+
 class EduCredential:
     def __init__(self, offer_id, credential_configuration_id, badge_instance):
         self.offer_id = offer_id
         self.credential_configuration_id = credential_configuration_id
         self.credential = Credential(
             issuer=badge_instance.badgeclass.issuer,
+            valid_from = badge_instance.issued_on,
             credential_subject= { "achievement": Achievement.from_badge_instance(badge_instance) }
         )
 
+        if badge_instance.expires_at:
+            self.credential.valid_until = badge_instance.expires_at
+
 class Credential:
-    def __init__(self, issuer, credential_subject):
+    def __init__(self, issuer, valid_from, credential_subject, **kwargs):
         self.issuer = issuer
+        self.valid_from = valid_from
         self.credential_subject = credential_subject
+
+        self.valid_until = kwargs.get('valid_until', None)
 
 class Achievement:
     def __init__(self, id, criteria, description, name, image):

--- a/apps/ob3/models.py
+++ b/apps/ob3/models.py
@@ -22,20 +22,26 @@ class Credential:
         self.valid_until = kwargs.get('valid_until', None)
 
 class Achievement:
-    def __init__(self, id, criteria, description, name, image):
+    def __init__(self, id, criteria, description, name, image, in_language):
         self.id = id
         self.criteria = criteria
         self.description = description
         self.name = name
         self.image = image
+        self.in_language = in_language
 
     @staticmethod
     def from_badge_instance(badge_instance):
         badge_class = badge_instance.badgeclass
+        in_language = None
+        if badge_class.extension_items["extensions:LanguageExtension"]:
+            in_language = badge_class.extension_items["extensions:LanguageExtension"]["Language"]
+
         return Achievement(
             id=badge_instance.entity_id,
             criteria= { "narrative": badge_class.criteria_text }, 
             description=badge_class.description,
             name=badge_class.name,
-            image= { "id": badge_class.image_url() }
+            image= { "id": badge_class.image_url() },
+            in_language=in_language
         )

--- a/apps/ob3/models.py
+++ b/apps/ob3/models.py
@@ -18,6 +18,38 @@ def generate_sha256_hashstring(identifier: str, salt: Optional[str]=None):
     """
     key = '{}{}'.format(identifier.lower(), salt if salt is not None else "")
     return 'sha256$' + sha256(key.encode('utf-8')).hexdigest()
+
+# Mixin to provide dynamic field assignment to a class
+class StructFieldsMixin:
+    FIELDS = []
+
+    def __init__(self, **kwargs):
+        """
+        Initialize the course with dynamic field assignment.
+        Fields are validated against FIELDS class variable.
+
+        Args:
+            **kwargs: Keyword arguments corresponding to FIELDS
+
+        Raises:
+            ValueError: If any provided field is not in FIELDS or if any field
+                        is missing
+        """
+        # Check for invalid fields
+        invalid_fields = set(kwargs.keys()) - set(self.FIELDS)
+        if invalid_fields:
+            raise ValueError(f"Invalid fields provided: {invalid_fields}")
+
+        # Check for missing fields
+        missing_fields = set(self.FIELDS) - set(kwargs.keys())
+        if missing_fields:
+            raise ValueError(f"Missing required fields: {missing_fields}")
+
+        for field in self.FIELDS:
+            setattr(self, field, kwargs.get(field, None))
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
 # A plain old Python object (POPO) that represents an educational credential
 class OfferRequest:
     def __init__(self, offer_id, credential_configuration_id, badge_instance):
@@ -83,6 +115,7 @@ class IdentityObject:
                 badge_instance.salt
         )
 
+class Achievement(StructFieldsMixin):
     FIELDS = [
             'id',
             'criteria',
@@ -95,31 +128,6 @@ class IdentityObject:
             'participation',
             'alignment',
             ]
-
-    def __init__(self, **kwargs):
-        """
-        Initialize the course with dynamic field assignment.
-        Fields are validated against FIELDS class variable.
-
-        Args:
-            **kwargs: Keyword arguments corresponding to FIELDS
-
-        Raises:
-            ValueError: If any provided field is not in FIELDS or if any field
-                        is missing
-        """
-        # Check for invalid fields
-        invalid_fields = set(kwargs.keys()) - set(self.FIELDS)
-        if invalid_fields:
-            raise ValueError(f"Invalid fields provided: {invalid_fields}")
-
-        # Check for missing fields
-        missing_fields = set(self.FIELDS) - set(kwargs.keys())
-        if missing_fields:
-            raise ValueError(f"Missing required fields: {missing_fields}")
-
-        for field in self.FIELDS:
-            setattr(self, field, kwargs.get(field, None))
 
     @staticmethod
     def from_badge_instance(badge_instance):

--- a/apps/ob3/models.py
+++ b/apps/ob3/models.py
@@ -155,6 +155,6 @@ class Achievement(StructFieldsMixin):
             ects=ects,
             education_program_identifier=education_program_identifier,
             participation=badge_class.participation,
-            alignment=badge_class.alignments, # NOTE singular and plural.
+            alignment=badge_class.alignment_items
         )
 

--- a/apps/ob3/models.py
+++ b/apps/ob3/models.py
@@ -31,6 +31,7 @@ class Achievement:
             'in_language',
             'name',
             'participation',
+            'alignment',
             ]
 
     def __init__(self, **kwargs):
@@ -84,4 +85,5 @@ class Achievement:
             ects=ects,
             education_program_identifier=education_program_identifier,
             participation=badge_class.participation,
+            alignment=badge_class.alignments, # NOTE singular and plural.
         )

--- a/apps/ob3/models.py
+++ b/apps/ob3/models.py
@@ -1,5 +1,5 @@
 # A plain old Python object (POPO) that represents an educational credential
-class EduCredential:
+class OfferRequest:
     def __init__(self, offer_id, credential_configuration_id, badge_instance):
         self.offer_id = offer_id
         self.credential_configuration_id = credential_configuration_id

--- a/apps/ob3/models.py
+++ b/apps/ob3/models.py
@@ -21,7 +21,7 @@ class Credential:
         self.valid_until = kwargs.get('valid_until', None)
 
 class Achievement:
-    FIELDS = ['id', 'criteria', 'description', 'name', 'image', 'in_language', 'ects']
+    FIELDS = ['id', 'criteria', 'description', 'name', 'image', 'in_language', 'ects', 'education_program_identifier']
 
     def __init__(self, **kwargs):
         """
@@ -53,12 +53,16 @@ class Achievement:
         badge_class = badge_instance.badgeclass
         in_language = None
         ects = None
+        education_program_identifier = None
 
         if "extensions:LanguageExtension" in badge_class.extension_items:
             in_language = badge_class.extension_items["extensions:LanguageExtension"]["Language"]
 
         if "extensions:ECTSExtension" in badge_class.extension_items:
             ects = badge_class.extension_items["extensions:ECTSExtension"]["ECTS"]
+
+        if "extensions:EducationProgramIdentifierExtension" in badge_class.extension_items:
+            education_program_identifier = badge_class.extension_items["extensions:EducationProgramIdentifierExtension"]["EducationProgramIdentifier"]
 
         return Achievement(
             id=badge_instance.entity_id,
@@ -67,5 +71,6 @@ class Achievement:
             name=badge_class.name,
             image= { "id": badge_class.image_url() },
             in_language=in_language,
-            ects=ects
+            ects=ects,
+            education_program_identifier=education_program_identifier
         )

--- a/apps/ob3/models.py
+++ b/apps/ob3/models.py
@@ -34,7 +34,7 @@ class Achievement:
     def from_badge_instance(badge_instance):
         badge_class = badge_instance.badgeclass
         in_language = None
-        if badge_class.extension_items["extensions:LanguageExtension"]:
+        if "extensions:LanguageExtension" in badge_class.extension_items:
             in_language = badge_class.extension_items["extensions:LanguageExtension"]["Language"]
 
         return Achievement(

--- a/apps/ob3/models.py
+++ b/apps/ob3/models.py
@@ -21,7 +21,17 @@ class Credential:
         self.valid_until = kwargs.get('valid_until', None)
 
 class Achievement:
-    FIELDS = ['id', 'criteria', 'description', 'name', 'image', 'in_language', 'ects', 'education_program_identifier']
+    FIELDS = [
+            'id',
+            'criteria',
+            'description',
+            'ects',
+            'education_program_identifier',
+            'image',
+            'in_language',
+            'name',
+            'participation',
+            ]
 
     def __init__(self, **kwargs):
         """
@@ -72,5 +82,6 @@ class Achievement:
             image= { "id": badge_class.image_url() },
             in_language=in_language,
             ects=ects,
-            education_program_identifier=education_program_identifier
+            education_program_identifier=education_program_identifier,
+            participation=badge_class.participation,
         )

--- a/apps/ob3/models.py
+++ b/apps/ob3/models.py
@@ -1,0 +1,33 @@
+# A plain old Python object (POPO) that represents an educational credential
+class EduCredential:
+    def __init__(self, offer_id, credential_configuration_id, badge_instance):
+        self.offer_id = offer_id
+        self.credential_configuration_id = credential_configuration_id
+        self.credential = Credential(
+            issuer=badge_instance.badgeclass.issuer,
+            credential_subject= { "achievement": Achievement.from_badge_instance(badge_instance) }
+        )
+
+class Credential:
+    def __init__(self, issuer, credential_subject):
+        self.issuer = issuer
+        self.credential_subject = credential_subject
+
+class Achievement:
+    def __init__(self, id, criteria, description, name, image):
+        self.id = id
+        self.criteria = criteria
+        self.description = description
+        self.name = name
+        self.image = image
+
+    @staticmethod
+    def from_badge_instance(badge_instance):
+        badge_class = badge_instance.badgeclass
+        return Achievement(
+            id=badge_instance.entity_id,
+            criteria= { "narrative": badge_class.criteria_text }, 
+            description=badge_class.description,
+            name=badge_class.name,
+            image= { "id": badge_class.image_url() }
+        )

--- a/apps/ob3/serializers.py
+++ b/apps/ob3/serializers.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict
 from django.utils import timezone
+
 from rest_framework import serializers
 
 from apps.mainsite.settings import UI_URL
@@ -84,6 +85,24 @@ class AlignmentSerializer(serializers.Serializer):
         ret["targetType"] = f"ext:{framework}Alignment"
         return ret
 
+class IdentityObjectSerializer(serializers.Serializer):
+    type = serializers.ListField(
+            child=serializers.CharField(),
+            read_only=True,
+            default=["IdentityObject"]
+    )
+    identityHash = serializers.CharField(
+            source='identity_hash',
+            required=True,
+    )
+    hashed = serializers.BooleanField()
+    identityType = serializers.CharField(
+            source='identity_type',
+    )
+    salt = serializers.CharField(
+            required=False,
+            allow_null=True,
+    )
 
 class AchievementSerializer(OmitNoneFieldsMixin, serializers.Serializer):
     OMIT_IF_NONE = ['inLanguage', 'ECTS', 'educationProgramIdentifier', 'participationType', 'alignment']
@@ -130,13 +149,19 @@ class AchievementSerializer(OmitNoneFieldsMixin, serializers.Serializer):
 
         return ret
 
-class AchievementSubjectSerializer(serializers.Serializer):
+class AchievementSubjectSerializer(OmitNoneFieldsMixin, serializers.Serializer):
+    OMIT_IF_NONE = ['identifier']
+
     type = serializers.ListField(
             child=serializers.CharField(),
             read_only=True,
             default=["AchievementSubject"]
     )
     achievement = AchievementSerializer()
+    identifier = IdentityObjectSerializer(
+            required=False,
+            allow_null=True,
+    )
 
 class CredentialSerializer(OmitNoneFieldsMixin, serializers.Serializer):
     OMIT_IF_NONE = ['validFrom', 'validUntil']

--- a/apps/ob3/serializers.py
+++ b/apps/ob3/serializers.py
@@ -1,0 +1,60 @@
+from rest_framework import serializers
+
+from apps.mainsite.settings import UI_URL
+
+class IssuerSerializer(serializers.Serializer):
+    id = serializers.URLField()
+    type = serializers.ListField(
+            child=serializers.CharField(),
+            read_only=True,
+            default=["Profile"]
+        )
+    name = serializers.CharField()
+
+    def to_representation(self, instance):
+        ret = super().to_representation(instance)
+        """Convert the id to a URL"""
+        ret['id'] = f"{UI_URL}/ob3/issuers/{ret['id']}"
+        return ret
+
+class ImageSerializer(serializers.Serializer):
+    type = serializers.CharField(read_only=True, default="Image")
+    id = serializers.URLField()
+
+class AchievementSerializer(serializers.Serializer):
+    id = serializers.URLField()
+    type = serializers.ListField(
+            child=serializers.CharField(),
+            read_only=True,
+            default=["Achievement"]
+    )
+    criteria = serializers.DictField(child=serializers.CharField())
+    description = serializers.CharField()
+    name = serializers.CharField()
+    image = ImageSerializer()
+
+    def to_representation(self, instance):
+        ret = super().to_representation(instance)
+        # TODO: Decide how to handle public vs private assertions: the latter won't resolve
+        # TODO: DRY the id-to-url conversion
+        """Convert the id to a URL"""
+        ret['id'] = f"{UI_URL}/public/assertions/{ret['id']}"
+
+        return ret
+
+class AchievementSubjectSerializer(serializers.Serializer):
+    type = serializers.ListField(
+            child=serializers.CharField(),
+            read_only=True,
+            default=["AchievementSubject"]
+    )
+    achievement = AchievementSerializer()
+
+class CredentialSerializer(serializers.Serializer):
+    issuer = IssuerSerializer()
+    credentialSubject = AchievementSubjectSerializer(source='credential_subject')
+
+class EduCredentialSerializer(serializers.Serializer):
+    offerId = serializers.CharField(source='offer_id')
+    credentialConfigurationId = serializers.CharField(source='credential_configuration_id')
+    credential = CredentialSerializer()

--- a/apps/ob3/serializers.py
+++ b/apps/ob3/serializers.py
@@ -33,6 +33,11 @@ class AchievementSerializer(serializers.Serializer):
     description = serializers.CharField()
     name = serializers.CharField()
     image = ImageSerializer()
+    inLanguage = serializers.CharField(
+            source='in_language',
+            required=False,
+            allow_null=True,
+    )
 
     def to_representation(self, instance):
         ret = super().to_representation(instance)
@@ -40,6 +45,12 @@ class AchievementSerializer(serializers.Serializer):
         # TODO: DRY the id-to-url conversion
         """Convert the id to a URL"""
         ret['id'] = f"{UI_URL}/public/assertions/{ret['id']}"
+
+        """Remove a list of specific fields if they are None"""
+        to_remove = ['inLanguage']
+        for key in to_remove:
+            if ret.get(key) is None:
+                ret.pop(key)
 
         return ret
 

--- a/apps/ob3/serializers.py
+++ b/apps/ob3/serializers.py
@@ -69,6 +69,7 @@ class AchievementSerializer(OmitNoneFieldsMixin, serializers.Serializer):
             source='ects',
             decimal_places=1,
             max_digits=3, # Up to 99,9 ECTS (in reality, it's up to 10.0, IIRC)
+            coerce_to_string=False,
     )
 
     def to_representation(self, instance):

--- a/apps/ob3/serializers.py
+++ b/apps/ob3/serializers.py
@@ -81,7 +81,7 @@ class AlignmentSerializer(serializers.Serializer):
 
         # TODO: decide on what to do if framework is missing
         # TODO: we should really make this an enum with allowed values instead
-        framework = instance.get("target_framework", "")
+        framework = instance.target_framework
         ret["targetType"] = f"ext:{framework}Alignment"
         return ret
 

--- a/apps/ob3/serializers.py
+++ b/apps/ob3/serializers.py
@@ -48,7 +48,7 @@ class ImageSerializer(serializers.Serializer):
     id = serializers.URLField()
 
 class AchievementSerializer(OmitNoneFieldsMixin, serializers.Serializer):
-    OMIT_IF_NONE = ['inLanguage', 'ECTS', 'educationProgramIdentifier']
+    OMIT_IF_NONE = ['inLanguage', 'ECTS', 'educationProgramIdentifier', 'participationType']
 
     id = serializers.URLField()
     type = serializers.ListField(
@@ -73,6 +73,11 @@ class AchievementSerializer(OmitNoneFieldsMixin, serializers.Serializer):
     )
     educationProgramIdentifier = serializers.CharField(
             source='education_program_identifier',
+            required=False,
+            allow_null=True,
+    )
+    participationType = serializers.CharField(
+            source='participation',
             required=False,
             allow_null=True,
     )

--- a/apps/ob3/serializers.py
+++ b/apps/ob3/serializers.py
@@ -112,7 +112,7 @@ class CredentialSerializer(OmitNoneFieldsMixin, serializers.Serializer):
     )
     credentialSubject = AchievementSubjectSerializer(source='credential_subject')
 
-class EduCredentialSerializer(serializers.Serializer):
+class OfferRequestSerializer(serializers.Serializer):
     offerId = serializers.CharField(source='offer_id')
     credentialConfigurationId = serializers.CharField(source='credential_configuration_id')
     credential = CredentialSerializer()

--- a/apps/ob3/serializers.py
+++ b/apps/ob3/serializers.py
@@ -48,7 +48,7 @@ class ImageSerializer(serializers.Serializer):
     id = serializers.URLField()
 
 class AchievementSerializer(OmitNoneFieldsMixin, serializers.Serializer):
-    OMIT_IF_NONE = ['inLanguage', 'ECTS']
+    OMIT_IF_NONE = ['inLanguage', 'ECTS', 'educationProgramIdentifier']
 
     id = serializers.URLField()
     type = serializers.ListField(
@@ -70,6 +70,11 @@ class AchievementSerializer(OmitNoneFieldsMixin, serializers.Serializer):
             decimal_places=1,
             max_digits=3, # Up to 99,9 ECTS (in reality, it's up to 10.0, IIRC)
             coerce_to_string=False,
+    )
+    educationProgramIdentifier = serializers.CharField(
+            source='education_program_identifier',
+            required=False,
+            allow_null=True,
     )
 
     def to_representation(self, instance):

--- a/apps/ob3/serializers.py
+++ b/apps/ob3/serializers.py
@@ -1,3 +1,4 @@
+from django.utils import timezone
 from rest_framework import serializers
 
 from apps.mainsite.settings import UI_URL
@@ -52,7 +53,30 @@ class AchievementSubjectSerializer(serializers.Serializer):
 
 class CredentialSerializer(serializers.Serializer):
     issuer = IssuerSerializer()
+    validFrom = serializers.DateTimeField(
+            source='valid_from',
+            required=False,
+            allow_null=True,
+            default_timezone=timezone.utc
+    )
+    validUntil = serializers.DateTimeField(
+            source='valid_until',
+            required=False,
+            allow_null=True,
+            default_timezone=timezone.utc
+    )
     credentialSubject = AchievementSubjectSerializer(source='credential_subject')
+
+    def to_representation(self, instance):
+        ret = super().to_representation(instance)
+
+        """Remove a list of specific fields if they are None"""
+        to_remove = ['validFrom', 'validUntil']
+        for key in to_remove:
+            if ret.get(key) is None:
+                ret.pop(key)
+
+        return ret
 
 class EduCredentialSerializer(serializers.Serializer):
     offerId = serializers.CharField(source='offer_id')

--- a/apps/ob3/tests.py
+++ b/apps/ob3/tests.py
@@ -102,7 +102,8 @@ class TestCredentialsSerializers(SimpleTestCase):
                 "extensions:ECTSExtension": { "ECTS": 2.5 }
                 }
         actual_data = self._serialize_it(badge_instance)
-        self.assertEqual(actual_data["credential"]["credentialSubject"]["achievement"]["ECTS"], '2.5')
+        # It must be serialized as a Number, not a string
+        self.assertEqual(actual_data["credential"]["credentialSubject"]["achievement"]["ECTS"], 2.5)
 
     def _serialize_it(self, badge_instance: BadgeInstanceMock):
        edu_credential = EduCredential("offer_id", "credential_configuration_id", badge_instance)

--- a/apps/ob3/tests.py
+++ b/apps/ob3/tests.py
@@ -33,8 +33,8 @@ class IssuerMock:
 class TestCredentialsSerializers(SimpleTestCase):
     def test_serializer_serializes_credential(self):
         badge_instance = BadgeInstanceMock()
-        edu_credential = EduCredential("offer_id", "credential_configuration_id", badge_instance)
-        serializer = EduCredentialSerializer(edu_credential)
+        actual_data = self._serialize_it(badge_instance)
+
         expected_data = {
             "offerId": "offer_id",
             "credentialConfigurationId": "credential_configuration_id",
@@ -63,33 +63,30 @@ class TestCredentialsSerializers(SimpleTestCase):
             }
         }
 
-        actual_data = dict(serializer.data)
         self.maxDiff = None # Debug full diff
         self.assertDictEqual(actual_data, expected_data)
 
     def test_optional_valid_from_field_set(self):
         badge_instance = BadgeInstanceMock()
         badge_instance.issued_on = DateTime.fromisoformat("2020-01-01:01:13:37")
-
-        edu_credential = EduCredential("offer_id", "credential_configuration_id", badge_instance)
-        actual_data = dict(EduCredentialSerializer(edu_credential).data)
+        actual_data = self._serialize_it(badge_instance)
 
         self.assertEqual(actual_data["credential"]["validFrom"], "2020-01-01T01:13:37Z")
 
     def test_optional_valid_from_field_notset(self):
         badge_instance = BadgeInstanceMock()
         badge_instance.issued_on = None
-
-        edu_credential = EduCredential("offer_id", "credential_configuration_id", badge_instance)
-        actual_data = dict(EduCredentialSerializer(edu_credential).data)
+        actual_data = self._serialize_it(badge_instance)
 
         self.assertNotIn("validFrom", actual_data)
 
     def test_optional_valid_until(self):
         badge_instance = BadgeInstanceMock()
         badge_instance.expires_at = DateTime.fromisoformat("2020-01-01:01:13:37")
-
-        edu_credential = EduCredential("offer_id", "credential_configuration_id", badge_instance)
-        actual_data = dict(EduCredentialSerializer(edu_credential).data)
+        actual_data = self._serialize_it(badge_instance)
 
         self.assertEqual(actual_data["credential"]["validUntil"], "2020-01-01T01:13:37Z")
+
+    def _serialize_it(self, badge_instance: BadgeInstanceMock):
+       edu_credential = EduCredential("offer_id", "credential_configuration_id", badge_instance)
+       return dict(EduCredentialSerializer(edu_credential).data)

--- a/apps/ob3/tests.py
+++ b/apps/ob3/tests.py
@@ -96,6 +96,14 @@ class TestCredentialsSerializers(SimpleTestCase):
         actual_data = self._serialize_it(badge_instance)
         self.assertEqual(actual_data["credential"]["credentialSubject"]["achievement"]["inLanguage"], "en_EN")
 
+    def test_studyload_extension(self):
+        badge_instance = BadgeInstanceMock()
+        badge_instance.badgeclass.extension_items = {
+                "extensions:ECTSExtension": { "ECTS": 2.5 }
+                }
+        actual_data = self._serialize_it(badge_instance)
+        self.assertEqual(actual_data["credential"]["credentialSubject"]["achievement"]["ECTS"], '2.5')
+
     def _serialize_it(self, badge_instance: BadgeInstanceMock):
        edu_credential = EduCredential("offer_id", "credential_configuration_id", badge_instance)
        return dict(EduCredentialSerializer(edu_credential).data)

--- a/apps/ob3/tests.py
+++ b/apps/ob3/tests.py
@@ -14,6 +14,7 @@ class BadgeClassMock:
         self.description = "This badge is a Lorem Ipsum, **dolor** _sit_ amet"
         self.name = "Mock Badge"
         self.issuer = IssuerMock()
+        self.extension_items = {}
 
     def image_url(self):
         return "https://example.com/images/mock.png"
@@ -86,6 +87,14 @@ class TestCredentialsSerializers(SimpleTestCase):
         actual_data = self._serialize_it(badge_instance)
 
         self.assertEqual(actual_data["credential"]["validUntil"], "2020-01-01T01:13:37Z")
+
+    def test_optional_education_language_extension(self):
+        badge_instance = BadgeInstanceMock()
+        badge_instance.badgeclass.extension_items = {
+                "extensions:LanguageExtension": { "Language": "en_EN" }
+                }
+        actual_data = self._serialize_it(badge_instance)
+        self.assertEqual(actual_data["credential"]["credentialSubject"]["achievement"]["inLanguage"], "en_EN")
 
     def _serialize_it(self, badge_instance: BadgeInstanceMock):
        edu_credential = EduCredential("offer_id", "credential_configuration_id", badge_instance)

--- a/apps/ob3/tests.py
+++ b/apps/ob3/tests.py
@@ -1,5 +1,7 @@
 from django.test import SimpleTestCase
 
+from datetime import datetime as DateTime
+
 from .models import EduCredential
 from .serializers import EduCredentialSerializer
 
@@ -19,13 +21,15 @@ class BadgeInstanceMock:
     def __init__(self):
         self.entity_id = "BADGE1234"
         self.badgeclass = BadgeClassMock()
+        self.issued_on = None
+        self.expires_at = None
 
 class IssuerMock:
     def __init__(self):
         self.id = "ISS1234"
         self.name = "Mock Issuer"
 
-class TestCredentialsView(SimpleTestCase):
+class TestCredentialsSerializers(SimpleTestCase):
     def test_serializer_serializes_credential(self):
         badge_instance = BadgeInstanceMock()
         edu_credential = EduCredential("offer_id", "credential_configuration_id", badge_instance)
@@ -61,3 +65,30 @@ class TestCredentialsView(SimpleTestCase):
         actual_data = dict(serializer.data)
         self.maxDiff = None # Debug full diff
         self.assertDictEqual(actual_data, expected_data)
+
+    def test_optional_valid_from_field_set(self):
+        badge_instance = BadgeInstanceMock()
+        badge_instance.issued_on = DateTime.fromisoformat("2020-01-01:01:13:37")
+
+        edu_credential = EduCredential("offer_id", "credential_configuration_id", badge_instance)
+        actual_data = dict(EduCredentialSerializer(edu_credential).data)
+
+        self.assertEqual(actual_data["credential"]["validFrom"], "2020-01-01T01:13:37Z")
+
+    def test_optional_valid_from_field_notset(self):
+        badge_instance = BadgeInstanceMock()
+        badge_instance.issued_on = None
+
+        edu_credential = EduCredential("offer_id", "credential_configuration_id", badge_instance)
+        actual_data = dict(EduCredentialSerializer(edu_credential).data)
+
+        self.assertNotIn("validFrom", actual_data)
+
+    def test_optional_valid_until(self):
+        badge_instance = BadgeInstanceMock()
+        badge_instance.expires_at = DateTime.fromisoformat("2020-01-01:01:13:37")
+
+        edu_credential = EduCredential("offer_id", "credential_configuration_id", badge_instance)
+        actual_data = dict(EduCredentialSerializer(edu_credential).data)
+
+        self.assertEqual(actual_data["credential"]["validUntil"], "2020-01-01T01:13:37Z")

--- a/apps/ob3/tests.py
+++ b/apps/ob3/tests.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from django.test import SimpleTestCase
 
 from datetime import datetime as DateTime
@@ -21,8 +22,8 @@ class BadgeInstanceMock:
     def __init__(self):
         self.entity_id = "BADGE1234"
         self.badgeclass = BadgeClassMock()
-        self.issued_on = None
-        self.expires_at = None
+        self.issued_on: Optional[DateTime] = None
+        self.expires_at: Optional[DateTime] = None
 
 class IssuerMock:
     def __init__(self):

--- a/apps/ob3/tests.py
+++ b/apps/ob3/tests.py
@@ -14,6 +14,7 @@ class BadgeClassMock:
         self.description = "This badge is a Lorem Ipsum, **dolor** _sit_ amet"
         self.name = "Mock Badge"
         self.issuer = IssuerMock()
+        self.participation: Optional[str] = None
         self.extension_items = {}
 
     def image_url(self):
@@ -112,6 +113,13 @@ class TestCredentialsSerializers(SimpleTestCase):
                 }
         actual_data = self._serialize_it(badge_instance)
         self.assertEqual(actual_data["credential"]["credentialSubject"]["achievement"]["educationProgramIdentifier"], "1234")
+
+    def test_participation_type(self):
+        badge_instance = BadgeInstanceMock()
+        badge_instance.badgeclass.participation = "blended"
+
+        actual_data = self._serialize_it(badge_instance)
+        self.assertEqual(actual_data["credential"]["credentialSubject"]["achievement"]["participationType"], "blended")
 
     def _serialize_it(self, badge_instance: BadgeInstanceMock):
        edu_credential = OfferRequest("offer_id", "credential_configuration_id", badge_instance)

--- a/apps/ob3/tests.py
+++ b/apps/ob3/tests.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import List, Optional
 from django.test import SimpleTestCase
 
 from datetime import datetime as DateTime
@@ -15,7 +15,7 @@ class BadgeClassMock:
         self.name = "Mock Badge"
         self.issuer = IssuerMock()
         self.participation: Optional[str] = None
-        self.alignments = []
+        self.alignment_items: List[AligmentItemMock] = []
         self.extension_items = {}
 
     def image_url(self):
@@ -35,6 +35,14 @@ class IssuerMock:
     def __init__(self):
         self.id = "ISS1234"
         self.name = "Mock Issuer"
+
+class AligmentItemMock:
+    def __init__(self):
+        self.target_name = "interne geneeskunde"
+        self.target_url = "https://example.com/esco/1337"
+        self.target_code = "1337"
+        self.target_framework = "ESCO"
+        self.target_description = "# example cool"
 
 def mock_hasher(_id, _salt):
    return "mock_hash"
@@ -144,13 +152,7 @@ class TestCredentialsSerializers(SimpleTestCase):
 
     def test_aligments(self):
         badge_instance = BadgeInstanceMock()
-        badge_instance.badgeclass.alignments = [{ 
-                 "target_name":"interne geneeskunde",
-                 "target_url":"https://example.com/esco/1337",
-                 "target_code":"1337",
-                 "target_framework":"ESCO",
-                 "target_description":"# example cool",
-        }]
+        badge_instance.badgeclass.alignment_items = [AligmentItemMock()]
         actual_data = self._serialize_it(badge_instance)
         actual_data = actual_data["credential"]["credentialSubject"]["achievement"]
         expected_alignment = {

--- a/apps/ob3/tests.py
+++ b/apps/ob3/tests.py
@@ -15,6 +15,7 @@ class BadgeClassMock:
         self.name = "Mock Badge"
         self.issuer = IssuerMock()
         self.participation: Optional[str] = None
+        self.alignments = []
         self.extension_items = {}
 
     def image_url(self):
@@ -120,6 +121,29 @@ class TestCredentialsSerializers(SimpleTestCase):
 
         actual_data = self._serialize_it(badge_instance)
         self.assertEqual(actual_data["credential"]["credentialSubject"]["achievement"]["participationType"], "blended")
+
+    def test_aligments(self):
+        badge_instance = BadgeInstanceMock()
+        badge_instance.badgeclass.alignments = [{ 
+                 "target_name":"interne geneeskunde",
+                 "target_url":"https://example.com/esco/1337",
+                 "target_code":"1337",
+                 "target_framework":"ESCO",
+                 "target_description":"# example cool",
+        }]
+        actual_data = self._serialize_it(badge_instance)
+        actual_data = actual_data["credential"]["credentialSubject"]["achievement"]
+        expected_alignment = {
+            "type": ["Alignment"],
+            "targetType": "ext:ESCOAlignment",
+            "targetName": "interne geneeskunde",
+            "targetDescription":"# example cool",
+            "targetUrl":"https://example.com/esco/1337",
+            "targetCode":"1337",
+        }
+
+        self.assertIn(expected_alignment, actual_data["alignment"])
+
 
     def _serialize_it(self, badge_instance: BadgeInstanceMock):
        edu_credential = OfferRequest("offer_id", "credential_configuration_id", badge_instance)

--- a/apps/ob3/tests.py
+++ b/apps/ob3/tests.py
@@ -105,6 +105,14 @@ class TestCredentialsSerializers(SimpleTestCase):
         # It must be serialized as a Number, not a string
         self.assertEqual(actual_data["credential"]["credentialSubject"]["achievement"]["ECTS"], 2.5)
 
+    def test_education_program_identifier_extension(self):
+        badge_instance = BadgeInstanceMock()
+        badge_instance.badgeclass.extension_items = {
+                "extensions:EducationProgramIdentifierExtension": { "EducationProgramIdentifier": "1234" }
+                }
+        actual_data = self._serialize_it(badge_instance)
+        self.assertEqual(actual_data["credential"]["credentialSubject"]["achievement"]["educationProgramIdentifier"], "1234")
+
     def _serialize_it(self, badge_instance: BadgeInstanceMock):
        edu_credential = EduCredential("offer_id", "credential_configuration_id", badge_instance)
        return dict(EduCredentialSerializer(edu_credential).data)

--- a/apps/ob3/tests.py
+++ b/apps/ob3/tests.py
@@ -3,8 +3,8 @@ from django.test import SimpleTestCase
 
 from datetime import datetime as DateTime
 
-from .models import EduCredential
-from .serializers import EduCredentialSerializer
+from .models import OfferRequest
+from .serializers import OfferRequestSerializer
 
 from  mainsite.settings import UI_URL
 
@@ -114,5 +114,5 @@ class TestCredentialsSerializers(SimpleTestCase):
         self.assertEqual(actual_data["credential"]["credentialSubject"]["achievement"]["educationProgramIdentifier"], "1234")
 
     def _serialize_it(self, badge_instance: BadgeInstanceMock):
-       edu_credential = EduCredential("offer_id", "credential_configuration_id", badge_instance)
-       return dict(EduCredentialSerializer(edu_credential).data)
+       edu_credential = OfferRequest("offer_id", "credential_configuration_id", badge_instance)
+       return dict(OfferRequestSerializer(edu_credential).data)

--- a/apps/ob3/tests.py
+++ b/apps/ob3/tests.py
@@ -88,7 +88,7 @@ class TestCredentialsSerializers(SimpleTestCase):
 
         self.assertEqual(actual_data["credential"]["validUntil"], "2020-01-01T01:13:37Z")
 
-    def test_optional_education_language_extension(self):
+    def test_education_language_extension(self):
         badge_instance = BadgeInstanceMock()
         badge_instance.badgeclass.extension_items = {
                 "extensions:LanguageExtension": { "Language": "en_EN" }

--- a/apps/ob3/tests.py
+++ b/apps/ob3/tests.py
@@ -1,0 +1,63 @@
+from django.test import SimpleTestCase
+
+from .models import EduCredential
+from .serializers import EduCredentialSerializer
+
+from  mainsite.settings import UI_URL
+
+class BadgeClassMock:
+    def __init__(self):
+        self.criteria_text = "You must Lorem Ipsum, **dolor** _sit_ amet"
+        self.description = "This badge is a Lorem Ipsum, **dolor** _sit_ amet"
+        self.name = "Mock Badge"
+        self.issuer = IssuerMock()
+
+    def image_url(self):
+        return "https://example.com/images/mock.png"
+
+class BadgeInstanceMock:
+    def __init__(self):
+        self.entity_id = "BADGE1234"
+        self.badgeclass = BadgeClassMock()
+
+class IssuerMock:
+    def __init__(self):
+        self.id = "ISS1234"
+        self.name = "Mock Issuer"
+
+class TestCredentialsView(SimpleTestCase):
+    def test_serializer_serializes_credential(self):
+        badge_instance = BadgeInstanceMock()
+        edu_credential = EduCredential("offer_id", "credential_configuration_id", badge_instance)
+        serializer = EduCredentialSerializer(edu_credential)
+        expected_data = {
+            "offerId": "offer_id",
+            "credentialConfigurationId": "credential_configuration_id",
+            "credential": {
+                "issuer": {
+                    "id": f"{UI_URL}/ob3/issuers/ISS1234",
+                    "type": ["Profile"],
+                    "name": "Mock Issuer"
+                },
+                "credentialSubject": {
+                    "type": ["AchievementSubject"],
+                    "achievement": {
+                        "id": f"{UI_URL}/public/assertions/BADGE1234",
+                        "type": ["Achievement"],
+                        "criteria": {
+                            "narrative": "You must Lorem Ipsum, **dolor** _sit_ amet"
+                        },
+                        "description": "This badge is a Lorem Ipsum, **dolor** _sit_ amet",
+                        "name": "Mock Badge",
+                        "image": {
+                            "type": "Image",
+                            "id": "https://example.com/images/mock.png"
+                        }
+                    }
+                }
+            }
+        }
+
+        actual_data = dict(serializer.data)
+        self.maxDiff = None # Debug full diff
+        self.assertDictEqual(actual_data, expected_data)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - BADGR_DB_PORT=3306
       - BADGR_DB_USER=badgr
       - DEBUG=1
+      - DJANGO_LOG_LEVEL=DEBUG
       - DEFAULT_DOMAIN=http://0.0.0.0:8000
       - DEFAULT_FROM_EMAIL=noreply@surf.nl
       - DOMAIN=0.0.0.0:8000


### PR DESCRIPTION
This adds additional fields to the credential output.

We start simple with validUntil and validFrom datefields- which are optional both. validFrom is always set in practice. validUntil not.

To achieve this, we've refactored the JSON generation first. Since building the json structure with conditional fields turns messy really fast, we've opted for a serializer-pattern. As follows:

![image](https://github.com/user-attachments/assets/4081ff1b-0f50-4d0d-89ac-e35821b79bad)

So, we have "models" as POPOs (plain old python objects), in a tree structure, with `EduCredential` as root, that we can serialize with corresponding serializers. This tree of "models" can be instantiated from actual Django Record BadgeInstance model.

Basically: we can now serialize Django BadgeInstance records as an OB3 JSON structure.

PR is in draft because it continues on #155 