### PR TITLE
Feature/unime rich credentials

### DIFF
--- a/apps/ob3/models.py
+++ b/apps/ob3/models.py
@@ -84,7 +84,8 @@ class AchievementSubject:
     def from_badge_instance(badge_instance):
         achievement = Achievement.from_badge_instance(badge_instance)
         if badge_instance.recipient_identifier and badge_instance.salt:
-            identifier = IdentityObject.from_badge_instance(badge_instance)
+            # Hardcoded to one element. The spec allows more, but we don't need it.
+            identifier = [IdentityObject.from_badge_instance(badge_instance)]
         else:
             identifier = None
 

--- a/apps/ob3/serializers.py
+++ b/apps/ob3/serializers.py
@@ -86,10 +86,9 @@ class AlignmentSerializer(serializers.Serializer):
         return ret
 
 class IdentityObjectSerializer(serializers.Serializer):
-    type = serializers.ListField(
-            child=serializers.CharField(),
+    type = serializers.CharField(
             read_only=True,
-            default=["IdentityObject"]
+            default="IdentityObject"
     )
     identityHash = serializers.CharField(
             source='identity_hash',
@@ -158,9 +157,11 @@ class AchievementSubjectSerializer(OmitNoneFieldsMixin, serializers.Serializer):
             default=["AchievementSubject"]
     )
     achievement = AchievementSerializer()
-    identifier = IdentityObjectSerializer(
-            required=False,
-            allow_null=True,
+    identifier = serializers.ListField(
+            child=IdentityObjectSerializer(
+                required=False,
+                allow_null=True,
+                )
     )
 
 class CredentialSerializer(OmitNoneFieldsMixin, serializers.Serializer):

--- a/apps/ob3/tests.py
+++ b/apps/ob3/tests.py
@@ -89,13 +89,14 @@ class TestCredentialsSerializers(SimpleTestCase):
         badge_instance.salt = "s@lt"
         actual_data = self._serialize_it(badge_instance)
         expected_identifier = {
-            "type": ["IdentityObject"],
+            "type": "IdentityObject",
             "hashed": True,
             "identityHash": "sha256$a2441d313d3d31514464ed6732d255df3391cbc85dd374d8a94b683248dcb7b8",
             "identityType": "emailAddress",
             "salt": "s@lt",
         }
-        self.assertEqual(actual_data["credential"]["credentialSubject"]["identifier"], expected_identifier)
+        self.assertEqual(len(actual_data["credential"]["credentialSubject"]["identifier"]), 1)
+        self.assertEqual(actual_data["credential"]["credentialSubject"]["identifier"][0], expected_identifier)
 
     def test_optional_valid_from_field_set(self):
         badge_instance = BadgeInstanceMock()


### PR DESCRIPTION
This fixes the unime import button in the POC.

- The structure of the credential was wrong. identity should be an array and identity[].type a string.
- The code flow of issuing was   wrong: we called sphereon backend outside of the sphereon/unime type conditional. 