### PR TITLE
Feature/decimal bugfix

### DIFF
--- a/apps/ob3/serializers.py
+++ b/apps/ob3/serializers.py
@@ -21,7 +21,9 @@ class OmitNoneFieldsMixin:
 
     def to_representation(self, instance: Any) -> Dict[str, Any]:
         # Juggling to call the parent's to_representation method and not raise type errors
-        fallback_to_representation = lambda x: dict(x.__dict__)
+        def fallback_to_representation(x):
+            return dict(x.__dict__)
+
         representation = getattr(super(), 'to_representation', fallback_to_representation)(instance)
 
         for key in self.OMIT_IF_NONE:

--- a/apps/ob3/serializers.py
+++ b/apps/ob3/serializers.py
@@ -124,7 +124,7 @@ class AchievementSerializer(OmitNoneFieldsMixin, serializers.Serializer):
     ECTS = serializers.DecimalField(
             source='ects',
             decimal_places=1,
-            max_digits=3, # Up to 99,9 ECTS (in reality, it's up to 10.0, IIRC)
+            max_digits=4, # In reality there's a max at 240 for regular and 30 for microcredential. We don't handle that, yet
             coerce_to_string=False,
     )
     educationProgramIdentifier = serializers.CharField(

--- a/apps/ob3/tests.py
+++ b/apps/ob3/tests.py
@@ -127,14 +127,37 @@ class TestCredentialsSerializers(SimpleTestCase):
         actual_data = self._serialize_it(badge_instance)
         self.assertEqual(actual_data["credential"]["credentialSubject"]["achievement"]["inLanguage"], "en_EN")
 
-    def test_studyload_extension(self):
+    def test_ects_extension_int(self):
         badge_instance = BadgeInstanceMock()
         badge_instance.badgeclass.extension_items = {
-                "extensions:ECTSExtension": { "ECTS": 2.5 }
+                "extensions:ECTSExtension": { "ECTS": int(1) }
                 }
         actual_data = self._serialize_it(badge_instance)
-        # It must be serialized as a Number, not a string
+        self.assertEqual(actual_data["credential"]["credentialSubject"]["achievement"]["ECTS"], 1.0)
+
+    def test_ects_extension_float(self):
+        badge_instance = BadgeInstanceMock()
+        badge_instance.badgeclass.extension_items = {
+                "extensions:ECTSExtension": { "ECTS": float(2.5) }
+                }
+        actual_data = self._serialize_it(badge_instance)
         self.assertEqual(actual_data["credential"]["credentialSubject"]["achievement"]["ECTS"], 2.5)
+
+    def test_ects_extension_one_place(self):
+        badge_instance = BadgeInstanceMock()
+        badge_instance.badgeclass.extension_items = {
+                "extensions:ECTSExtension": { "ECTS": float(2.54321) }
+                }
+        actual_data = self._serialize_it(badge_instance)
+        self.assertEqual(actual_data["credential"]["credentialSubject"]["achievement"]["ECTS"], 2.5)
+
+    def test_ects_extension_max_999(self):
+        badge_instance = BadgeInstanceMock()
+        badge_instance.badgeclass.extension_items = {
+                "extensions:ECTSExtension": { "ECTS": float(240.0) }
+                }
+        actual_data = self._serialize_it(badge_instance)
+        self.assertEqual(actual_data["credential"]["credentialSubject"]["achievement"]["ECTS"], 240)
 
     def test_education_program_identifier_extension(self):
         badge_instance = BadgeInstanceMock()


### PR DESCRIPTION
Turns out this was an issue with our serializer configuration.

The serializers in DRF, however, didn't check for this and returned a type error, instead of a validation error or overflow error or something like that. 
Our config could only handle ECTS decimals up to three digits. With one decimal place, we could therefore handle up to 99.9. 


The badge we were testing with an ECTS of 240. DRF then crashed on serializing this somewhere deep in its decimal-library. 