### PR TITLE
chore: Ensure memcached is started before running migrations etc.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      memcached:
+        condition: service_started
     ports:
       - "8000:8000"
       


### PR DESCRIPTION
Else the migrations will fail when run separately. 

e.g. `docker compose run badgr python manage.py seed`