### PR TITLE
feat: Make the offer-id unpredictable for sphereon

### DIFF
--- a/apps/ob3/api.py
+++ b/apps/ob3/api.py
@@ -59,11 +59,12 @@ class CredentialsView(APIView):
             raise Http404
 
     def __issue_sphereon_badge(self, credential):
+        random_offer_id = str(uuid.uuid4());
         offer_request_body = {
             "credentials": ["OpenBadgeCredential"],
             "grants": {
                 "urn:ietf:params:oauth:grant-type:pre-authorized_code": {
-                    "pre-authorized_code": "This-is-sent-via-SMS",
+                    "pre-authorized_code": random_offer_id,
                     "user_pin_required": False
                 }
             },


### PR DESCRIPTION
We had it hardcoded. That caused "Race conditions" if multiple badges were being imported: the last badge offered would be sent to all users that were importing badges, regardless of if its theirs and if they were actually importing that badge.