### PR TITLE
Fix mailhog in dockerized environment

### DIFF
--- a/apps/mainsite/settings.py
+++ b/apps/mainsite/settings.py
@@ -565,7 +565,7 @@ DATABASES = {
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
 # Email
-EMAIL_USE_TLS = True
+EMAIL_USE_TLS = legacy_boolean_parsing('EMAIL_USE_TLS', '1')
 EMAIL_BACKEND = os.environ.get('EMAIL_BACKEND', 'django.core.mail.backends.console.EmailBackend')
 EMAIL_HOST = os.environ['EMAIL_HOST']
 EMAIL_PORT = int(os.environ.get('EMAIL_PORT', 25))

--- a/apps/mainsite/tests/test_settings.py
+++ b/apps/mainsite/tests/test_settings.py
@@ -1,0 +1,40 @@
+import os
+from unittest import TestCase
+from ..settings import legacy_boolean_parsing
+
+class TestLegacyBooleanParsing(TestCase):
+    def setUp(self):
+        # Store any existing environment variables to restore them later
+        self.original_env = os.environ.copy()
+
+    def tearDown(self):
+        # Restore original environment variables
+        os.environ.clear()
+        os.environ.update(self.original_env)
+
+    def test_string_true_returns_true(self):
+        os.environ['TEST_KEY'] = 'True'
+        self.assertTrue(legacy_boolean_parsing('TEST_KEY', '0'))
+
+    def test_string_false_returns_false(self):
+        os.environ['TEST_KEY'] = 'False'
+        self.assertFalse(legacy_boolean_parsing('TEST_KEY', '1'))
+
+    def test_numeric_1_returns_true(self):
+        os.environ['TEST_KEY'] = '1'
+        self.assertTrue(legacy_boolean_parsing('TEST_KEY', '0'))
+
+    def test_numeric_0_returns_false(self):
+        os.environ['TEST_KEY'] = '0'
+        self.assertFalse(legacy_boolean_parsing('TEST_KEY', '1'))
+
+    def test_missing_key_returns_default_true(self):
+        self.assertTrue(legacy_boolean_parsing('NONEXISTENT_KEY', '1'))
+
+    def test_missing_key_returns_default_false(self):
+        self.assertFalse(legacy_boolean_parsing('NONEXISTENT_KEY', '0'))
+
+    def test_invalid_value_raises_value_error(self):
+        os.environ['TEST_KEY'] = 'invalid'
+        with self.assertRaises(ValueError):
+            legacy_boolean_parsing('TEST_KEY', '0')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,8 @@ services:
       - EDUID_REGISTRATION_URL=https://login.test.eduid.nl/register
       - EDU_ID_CLIENT=edubadges
       - EDU_ID_SECRET=${EDU_ID_SECRET}
+      - EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
+      - EMAIL_USE_TLS=0
       - EMAIL_HOST=mailhog
       - EMAIL_PORT=1025
       - LTI_FRONTEND_URL=localhost
@@ -57,6 +59,8 @@ services:
       db:
         condition: service_healthy
       memcached:
+        condition: service_started
+      mailhog:
         condition: service_started
     ports:
       - "8000:8000"

--- a/env_vars.sh.example
+++ b/env_vars.sh.example
@@ -1,9 +1,18 @@
+export BADGR_DB_PASSWORD=""
+export OIDC_RS_SECRET="ask-a-colleague"
+export EDU_ID_SECRET="ask-a-colleague"
+export SURF_CONEXT_SECRET="ask-a-colleague"
+
+# Only needed when wallet import is used
+export OB3_AGENT_AUTHZ_TOKEN_SPHEREON="s3cr3t"
+
+# Not needed when running with Docker compose: Don't set these as they might break the app when
+#  it runs in the container
 export PYTHONUNBUFFERED=1
 export ACCOUNT_SALT="secret"
 export ALLOW_SEEDS=1
 export BADGR_DB_NAME="badgr"
 export BADGR_DB_USER="root"
-export BADGR_DB_PASSWORD=""
 export BADGR_DB_HOST=""
 export BADGR_DB_PORT="3306"
 export DEBUG=1
@@ -11,9 +20,7 @@ export DEFAULT_DOMAIN="http://127.0.0.1:8000"
 export DEFAULT_FROM_EMAIL="noreply@surf.nl"
 export DOMAIN="localhost:4000"
 export EDU_ID_CLIENT="edubadges"
-export EDU_ID_SECRET="ask-a-colleague"
 export OIDC_RS_ENTITY_ID="test.edubadges.rs.nl"
-export OIDC_RS_SECRET="ask-a-colleague"
 export EDUID_PROVIDER_URL="https://connect.test.surfconext.nl/oidc"
 export EDUID_REGISTRATION_URL="https://login.test.eduid.nl/register"
 export EMAIL_HOST="localhost"
@@ -27,7 +34,6 @@ export SITE_ID=1
 export BADGR_APP_ID=1
 export SURF_CONEXT_CLIENT="www.edubadges.nl"
 export SURF_CONEXT_CLIENT="test.edubadges.nl"
-export SURF_CONEXT_SECRET="secret"
 export TIME_STAMPED_OPEN_BADGES_BASE_URL="http://127.0.0.1:3000/"
 export UI_URL="http://localhost:4000"
 export UNSUBSCRIBE_SECRET_KEY="secret"
@@ -36,7 +42,6 @@ export LANG="en_US.UTF-8"
 export MEMCACHED="127.0.0.1:11211"
 export LOKI_API_URL="https://localhost"
 
-# Only needed when wallet import is used
+# Only needed when wallet import is used and only in a non-docker compose setup.
 export OB3_AGENT_URL_SPHEREON="http://localhost:5000"
-export OB3_AGENT_AUTHZ_TOKEN_SPHEREON="s3cr3t"
 export OB3_AGENT_URL_UNIME="http://localhost:6000"


### PR DESCRIPTION
This builds on top of #179 

We attempted to send it there, but it silently failed due to a few missing settings that got a default.
    
- For mailhog, in dev, we want the normal smpt delivery, not the built
      in django mailcatching
 - mailhog doesn't support TLS - obviously, so we must make this
      configurable rather than hardcoded, and set it to false for the
      dockerized version
