### PR TITLE
feat: Change "sphereon" issuer to issuer with authorization flow

### DIFF
--- a/apps/ob3/api.py
+++ b/apps/ob3/api.py
@@ -13,8 +13,8 @@ from pprint import pformat
 
 from issuer.models import BadgeInstance
 from mainsite.settings import OB3_AGENT_URL_SPHEREON, OB3_AGENT_AUTHZ_TOKEN_SPHEREON, OB3_AGENT_URL_UNIME
-from .serializers import OfferRequestSerializer
-from .models import OfferRequest
+from .serializers import ImpierceOfferRequestSerializer, SphereonOfferRequestSerializer
+from .models import ImpierceOfferRequest, SphereonOfferRequest
 
 logger = logging.getLogger('django')
 
@@ -32,24 +32,31 @@ class CredentialsView(APIView):
 
         badge_instance = self.__badge_instance(badge_id, request.user)
         logger.debug(f"Badge instance: {pformat(badge_instance.__dict__)}")
-        credential_configuration_id = {
-            'sphereon': "OpenBadgeCredential",
-            'unime': "openbadge_credential"
-        }.get(variant) 
-        credential = OfferRequest(offer_id, credential_configuration_id, badge_instance)
-        serializer = OfferRequestSerializer(credential)
 
-        if variant == 'sphereon':
+        if variant == 'authorization':
+            credential = SphereonOfferRequest(
+                    offer_id,
+                    "OpenBadgeCredential",
+                    badge_instance,
+                    request.user.entity_id, # TODO: how do we get an eduId?
+                    request.user.email,
+                    request.user.email, # TODO: how do we get an eppn?
+                    request.user.last_name,
+                    request.user.first_name,
+            )
+            serializer = SphereonOfferRequestSerializer(credential)
+            logger.debug(f"Credential: {pformat(serializer.data)}")
             offer = self.__issue_sphereon_badge(serializer.data)
             logger.debug(f"Sphereon offer: {offer}")
-        elif variant == 'unime':
+        elif variant == 'preauthorized':
+            credential = ImpierceOfferRequest(offer_id, "openbadge_credential", badge_instance)
+            serializer = ImpierceOfferRequestSerializer(credential)
+            logger.debug(f"Credential: {pformat(serializer.data)}")
             self.__issue_unime_badge(serializer.data)
             offer = self.__get_unime_offer(offer_id)
             logger.debug(f"Unime offer: {offer}")
 
         logger.info(f"Issued credential for badge {badge_id} with offer_id {offer_id}")
-        logger.debug(f"Credential: {pformat(serializer.data)}")
-
         return Response({"offer": offer}, status=status.HTTP_201_CREATED)
 
     def __badge_instance(self, badge_id, user):
@@ -58,39 +65,24 @@ class CredentialsView(APIView):
         except ObjectDoesNotExist:
             raise Http404
 
-    def __issue_sphereon_badge(self, credential):
-        random_offer_id = str(uuid.uuid4());
-        offer_request_body = {
-            "credentials": ["OpenBadgeCredential"],
-            "grants": {
-                "urn:ietf:params:oauth:grant-type:pre-authorized_code": {
-                    "pre-authorized_code": random_offer_id,
-                    "user_pin_required": False
-                }
-            },
-            "credentialDataSupplierInput": credential
-        }
-        resp = requests.post(
+    def __issue_sphereon_badge(self, credential_offer_request):
+        logger.debug(f"Requesting credential issuance: {OB3_AGENT_URL_SPHEREON} {credential_offer_request}")
+        response = requests.post(
                 timeout=5,
-                url=f"{OB3_AGENT_URL_SPHEREON}/edubadges/api/create-offer",
-                json=offer_request_body,
+                url=OB3_AGENT_URL_SPHEREON,
+                json=credential_offer_request,
                 headers={'Accept': 'application/json',
                          "Authorization": f"Bearer {OB3_AGENT_AUTHZ_TOKEN_SPHEREON}"}
         )
 
-        if resp.status_code >= 400:
-            msg = f"Failed to issue badge:\n\tcode: {resp.status_code}\n\tcontent:\n {resp.text}"
+        if response.status_code >= 400:
+            msg = f"Failed to issue badge:\n\tcode: {response.status_code}\n\tcontent:\n {response.text}"
             raise BadRequest(msg)
 
-
-        # We get back a json object that wraps an openid-credential-offer:// uri
-        # Inside this, is a a parameter credential_offer_uri that contains the actual offer uri
-        # Which we can fetch to get the offer
-        json_resp = resp.json()
-        return json_resp.get('uri')
+        return response.text
 
     def __issue_unime_badge(self, credential):
-        url = f"{OB3_AGENT_URL_UNIME}/v0/credentials"
+        url = OB3_AGENT_URL_UNIME
         headers = { 'Accept': 'application/json' }
         payload = credential
 
@@ -108,7 +100,7 @@ class CredentialsView(APIView):
             raise BadRequest(msg)
 
     def __get_unime_offer(self, offer_id):
-        url = f"{OB3_AGENT_URL_UNIME}/v0/offers"
+        url = f"{OB3_AGENT_URL_UNIME}"
         headers = { 'Accept': 'application/json' }
         payload = { "offerId": offer_id }
 

--- a/apps/ob3/models.py
+++ b/apps/ob3/models.py
@@ -51,7 +51,7 @@ class StructFieldsMixin:
             setattr(self, key, value)
 
 # A plain old Python object (POPO) that represents an educational credential
-class OfferRequest:
+class ImpierceOfferRequest:
     def __init__(self, offer_id, credential_configuration_id, badge_instance):
         self.offer_id = offer_id
         self.credential_configuration_id = credential_configuration_id
@@ -65,6 +65,28 @@ class OfferRequest:
 
         if badge_instance.expires_at:
             self.credential.valid_until = badge_instance.expires_at
+
+class SphereonOfferRequest:
+    def __init__(self, offer_id, credential_configuration_id, badge_instance, edu_id, email, eppn, family_name, given_name):
+        self.credential_configuration_ids = [credential_configuration_id]
+        self.grants = {
+            "authorization_code": {
+                "issuer_state": offer_id,
+            }
+        }
+        credential_subject = AchievementSubject.from_badge_instance(badge_instance)
+        self.credential = Credential(
+            issuer=badge_instance.badgeclass.issuer,
+            valid_from=badge_instance.issued_on,
+            credential_subject=credential_subject,
+        )
+        # TODO: Sphereon doesn't seem to support expiration dates yet, so we don't set it here.
+
+        self.edu_id = edu_id
+        self.email = email
+        self.eppn = eppn
+        self.family_name = family_name
+        self.given_name = given_name
 
 class Credential:
     def __init__(self, issuer, valid_from, credential_subject, **kwargs):

--- a/apps/ob3/serializers.py
+++ b/apps/ob3/serializers.py
@@ -184,7 +184,19 @@ class CredentialSerializer(OmitNoneFieldsMixin, serializers.Serializer):
     )
     credentialSubject = AchievementSubjectSerializer(source='credential_subject')
 
-class OfferRequestSerializer(serializers.Serializer):
+class SphereonOfferRequestSerializer(serializers.Serializer):
+    credential_configuration_ids = serializers.ListField()
+    grants = serializers.DictField()
+
+    credentialData = CredentialSerializer(source='credential')
+
+    eduId = serializers.CharField(source='edu_id')
+    email = serializers.EmailField()
+    eppn = serializers.EmailField()
+    familyName = serializers.CharField(source='family_name')
+    givenName = serializers.CharField(source='given_name')
+
+class ImpierceOfferRequestSerializer(serializers.Serializer):
     offerId = serializers.CharField(source='offer_id')
     credentialConfigurationId = serializers.CharField(source='credential_configuration_id')
     credential = CredentialSerializer()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,8 +45,8 @@ services:
       - TIME_STAMPED_OPEN_BADGES_BASE_URL=http://0.0.0.0:8000/
       - UI_URL=http://0.0.0.0:8080
       - UNSUBSCRIBE_SECRET_KEY=secret
-      - OB3_AGENT_URL_UNIME=https://agent.poc9.eduwallet.nl
-      - OB3_AGENT_URL_SPHEREON=http://veramo-agent:3000
+      - OB3_AGENT_URL_UNIME=https://agent.poc9.eduwallet.nl/v0/offers
+      - OB3_AGENT_URL_SPHEREON=https://agent.poc15.eduwallet.nl/oid4vci/admin/credentials
       - OB3_AGENT_AUTHZ_TOKEN_SPHEREON=${OB3_AGENT_AUTHZ_TOKEN_SPHEREON}
       - LOKI_API_URL=http://localhost
       - EXTENSIONS_ROOT_URL=http://localhost:8000/static

--- a/env_vars.sh.example
+++ b/env_vars.sh.example
@@ -1,3 +1,13 @@
+export BADGR_DB_PASSWORD=""
+export OIDC_RS_SECRET="ask-a-colleague"
+export EDU_ID_SECRET="ask-a-colleague"
+export SURF_CONEXT_SECRET="ask-a-colleague"
+
+# Only needed when wallet import is used
+export OB3_AGENT_AUTHZ_TOKEN_SPHEREON="s3cr3t"
+
+# Not needed when running with Docker compose: Don't set these as they might break the app when
+#  it runs in the container
 export PYTHONUNBUFFERED=1
 export ACCOUNT_SALT="secret"
 export ALLOW_SEEDS=1
@@ -36,7 +46,6 @@ export LANG="en_US.UTF-8"
 export MEMCACHED="127.0.0.1:11211"
 export LOKI_API_URL="https://localhost"
 
-# Only needed when wallet import is used
-export OB3_AGENT_URL_SPHEREON="http://localhost:5000"
-export OB3_AGENT_AUTHZ_TOKEN_SPHEREON="s3cr3t"
-export OB3_AGENT_URL_UNIME="http://localhost:6000"
+# Only needed when wallet import is used and only in a non-docker compose setup.
+export OB3_AGENT_URL_SPHEREON="http://localhost:5000/oid4vci/admin/credentials"
+export OB3_AGENT_URL_UNIME="http://localhost:6000/v0/credentials"


### PR DESCRIPTION
For this, we need to change some ENV vars.

We also need to differentiate between the request payload quite a lot, so we introduced two distinct serializes each with their own model for each type of request.

We then need to provide user-data with the authorization request, so that we provide the issuer with the nessecary details to determine if we are dealing with the expected user on issuance (the actual authorization).