### PR TITLE
Feature/ewi idp

### DIFF
--- a/apps/badgrsocialauth/providers/eduid/oidc_client.py
+++ b/apps/badgrsocialauth/providers/eduid/oidc_client.py
@@ -1,0 +1,154 @@
+import logging
+import requests
+
+from django.conf import settings
+
+logger = logging.getLogger('Badgr.Debug')
+
+class OidcClient:
+    """
+    This class is used to store the openid connect authorization server metadata.
+    """
+    def __init__(self):
+        self._userinfo_endpoint = None
+        self._introspect_endpoint = None
+
+    @staticmethod
+    def get_client_from_settings():
+        provider_name = settings.EDUID_OIDC_PROVIDER_NAME
+
+        if provider_name == 'eduid':
+            return EduIdOidcClient()
+        elif provider_name == 'surfconext':
+            return SurfConextOidcClient()
+        else:
+            raise Exception(f'Unknown provider name {provider_name}')
+    
+    def get_userinfo(self, access_token):
+        """
+        This function is used to get the userinfo from the OIDC provider.
+        It is used to get the userinfo from the OIDC provider.
+        """
+        if not self._userinfo_endpoint:
+            raise Exception('Userinfo endpoint not set')
+        headers = {
+            'Authorization': f'Bearer {access_token}',
+            'Content-Type': 'application/json',
+        }
+        logger.debug(f'Calling userinfo endpoint {self._userinfo_endpoint}')
+        response = requests.get(self._userinfo_endpoint, headers=headers)
+        logger.debug(f'Userinfo endpoint response {response}')
+        if response.status_code != 200:
+            raise Exception(f'User info endpoint error (http {response.status_code}). Try alternative login methods')
+
+        return self.normalize_userinfo(response.json())
+
+    def normalize_userinfo(self, userinfo):
+        """
+        This function is used to normalize the userinfo from the OIDC provider.
+        It is used to get the userinfo from the OIDC provider.
+        """
+        raise NotImplementedError('This function should be implemented in the subclass')
+
+class EduIdOidcClient(OidcClient):
+    """
+    Overrides the userinfo endpoint for the eduid provider.
+    """
+    def __init__(self):
+        super().__init__()
+        self._userinfo_endpoint = f'{settings.EDUID_API_BASE_URL}/myconext/api/eduid/links'
+        self._introspect_endpoint = None
+
+    def normalize_userinfo(self, userinfo):
+        return EduIdUserInfo(userinfo)
+
+class SurfConextOidcClient(OidcClient):
+    """
+    Overrides the userinfo endpoint for the surfconext provider.
+
+    The actual endpoints should be fetched from https://connect.test.surfconext.nl/oidc/.well-known/openid-configuration
+    """
+    def __init__(self):
+        super().__init__()
+        self._userinfo_endpoint = f'{settings.EDUID_PROVIDER_URL}/userinfo'
+        self._introspect_endpoint = f'{settings.EDUID_PROVIDER_URL}/introspect'
+
+    def normalize_userinfo(self, userinfo):
+        return SurfConextUserInfo(userinfo)
+
+class UserInfo:
+    """
+    This class is used to store the userinfo from the OIDC provider.
+    """
+    def __init__(self):
+        self._validated_names = []
+
+    def has_validated_name(self):
+        """
+        This function is used to check if the user has a validated name.
+        """
+        return bool(self.validated_names())
+
+    def validated_names(self):
+        """
+        This function is used to get the validated names from the userinfo.
+        """
+        raise NotImplementedError('This function should be implemented in the subclass')
+
+    def validated_name(self):
+        """
+        This function is used to get a canonical validated name from the validated names
+        """
+        return self.validated_names()[0] if self.validated_names() else None
+
+    def eppn(self):
+        """
+        This function is used to get the eppn from the userinfo.
+        """
+        raise NotImplementedError('This function should be implemented in the subclass')
+
+    def schac_home_organization(self):
+        """
+        This function is used to get the schac_home_organization from the userinfo.
+        """
+        raise NotImplementedError('This function should be implemented in the subclass')
+
+class EduIdUserInfo(UserInfo):
+    """
+    This class is used to store the userinfo from the eduid myconext api endpoint.
+    """
+    def __init__(self, eppn_json):
+        super().__init__()
+        
+        self._validated_names = [info['validated_name'] for info in eppn_json if 'validated_name' in info]
+        self._eppn = [info['eppn'] for info in eppn_json if 'eppn' in info]
+        self._schac_home_organization = [info['schac_home_organization'] for info in eppn_json if 'schac_home_organization' in info]
+
+    def validated_names(self):
+        return self.validated_names
+
+    def eppn(self):
+        return self._eppn[0] if self._eppn else None
+
+    def schac_home_organization(self):
+        return self._schac_home_organization[0] if self._schac_home_organization else None
+
+class SurfConextUserInfo(UserInfo):
+    """
+    This class is used to store the userinfo from the surfconext api endpoint.
+    """
+    def __init__(self, userinfo):
+        super().__init__()
+        ## How do we get the validated name from the surfconext userinfo?
+        self._validated_names = [userinfo.get('name', None)]
+        self._eppn = userinfo.get('eduperson_principal_name', None)
+        self._schac_home_organization = userinfo.get('schac_home_organization', None)
+
+    def validated_names(self):
+        return self._validated_names
+
+    def eppn(self):
+        return self._eppn
+
+    def schac_home_organization(self):
+        return self._schac_home_organization

--- a/apps/badgrsocialauth/providers/eduid/oidc_client.py
+++ b/apps/badgrsocialauth/providers/eduid/oidc_client.py
@@ -125,7 +125,7 @@ class EduIdUserInfo(UserInfo):
         self._schac_home_organization = [info['schac_home_organization'] for info in eppn_json if 'schac_home_organization' in info]
 
     def validated_names(self):
-        return self.validated_names
+        return self._validated_names
 
     def eppn(self):
         return self._eppn[0] if self._eppn else None

--- a/apps/badgrsocialauth/providers/eduid/views.py
+++ b/apps/badgrsocialauth/providers/eduid/views.py
@@ -105,18 +105,19 @@ def callback(request):
         'Content-Type': 'application/x-www-form-urlencoded',
         'Cache-Control': 'no-cache',
     }
-    response = requests.post(
+    token_response = requests.post(
         '{}/token'.format(settings.EDUID_PROVIDER_URL),
         data=urllib.parse.urlencode(payload),
         headers=headers,
         timeout=60,
     )
-    if response.status_code != 200:
-        error = 'Server error: User info endpoint error (http %s). Try alternative login methods' % response.status_code
+    logger.debug(f'Token response: {token_response}')
+    if token_response.status_code != 200:
+        error = 'Server error: User info endpoint error (http %s). Try alternative login methods' % token_response.status_code
         logger.debug(error)
         return render_authentication_error(request, EduIDProvider.id, error=error)
 
-    token_json = response.json()
+    token_json = token_response.json()
     id_token = token_json['id_token']
     access_token = token_json['access_token']
     payload = jwt.get_unverified_claims(id_token)
@@ -163,7 +164,7 @@ def after_terms_agreement(request, **kwargs):
     """
     this is the second part of the callback, after consent has been given, or is user already exists
     """
-    badgr_app_pk, login_type, referer = json.loads(kwargs['state'])
+    badgr_app_pk, _login_type, _referer = json.loads(kwargs['state'])
     try:
         badgr_app_pk = int(badgr_app_pk)
     except:
@@ -295,7 +296,6 @@ def print_logout_message(sender, user, request, **kwargs):
 
 def print_login_message(sender, user, request, **kwargs):
     print('user logged in')
-
 
 user_logged_out.connect(print_logout_message)
 user_logged_in.connect(print_login_message)

--- a/apps/badgrsocialauth/providers/eduid/views.py
+++ b/apps/badgrsocialauth/providers/eduid/views.py
@@ -27,9 +27,9 @@ from badgrsocialauth.utils import (
 from issuer.models import BadgeClass, BadgeInstance
 from mainsite.models import BadgrApp
 from .provider import EduIDProvider
+from .oidc_client import OidcClient
 
 logger = logging.getLogger('Badgr.Debug')
-
 
 def encode(username, password):  # client_id, secret
     """Returns an HTTP basic authentication encrypted string given a valid
@@ -121,6 +121,15 @@ def callback(request):
     id_token = token_json['id_token']
     access_token = token_json['access_token']
     payload = jwt.get_unverified_claims(id_token)
+    logger.debug(f'Payload from eduID: {json.dumps(payload)}')
+
+    # TODO: move to a polymorphic class model like with UserInfo
+    edu_id_identifier = payload.get(settings.EDUID_IDENTIFIER, None)
+    if not edu_id_identifier:
+        error = 'Server error: No eduID identifier found in payload'
+        logger.debug(f'Trying to find {settings.EDUID_IDENTIFIER} in payload: {json.dumps(payload)}')
+        logger.error(error)
+        return render_authentication_error(request, EduIDProvider.id, error=error)
 
     social_account = get_social_account(payload[settings.EDUID_IDENTIFIER])
 
@@ -135,22 +144,21 @@ def callback(request):
         'role': 'student',
     }
 
+    # TODO: find a way to determine if we get data from EduID IDP or from one of our EWI IDPs
+    oidc_client = OidcClient.get_client_from_settings()
     if not social_account or not social_account.user.general_terms_accepted():
-        # Here we redirect to client, but we need to check if there is a validated account
-        headers = {
-            'Accept': 'application/json, application/json;charset=UTF-8',
-            'Authorization': f'Bearer {access_token}',
-        }
-        response = requests.get(f'{settings.EDUID_API_BASE_URL}/myconext/api/eduid/links', headers=headers, timeout=60)
-        if response.status_code != 200:
-            error = f'Server error: eduID eppn endpoint error ({response.status_code})'
+        try:
+            user_info = oidc_client.get_userinfo(access_token)
+
+        except Exception as e:
+            error = f'Server error: {e}'
             logger.debug(error)
             return render_authentication_error(request, EduIDProvider.id, error=error)
-        eppn_json = response.json()
-        validated_name = bool([info['validated_name'] for info in eppn_json if 'validated_name' in info])
+
         signup_redirect = badgr_app.signup_redirect
         args = urllib.parse.urlencode(keyword_arguments)
-        if not validated_name:
+
+        if not user_info.has_validated_name():
             validate_redirect = signup_redirect.replace('signup', 'validate')
             return HttpResponseRedirect(f'{validate_redirect}?{args}')
 
@@ -212,39 +220,38 @@ def after_terms_agreement(request, **kwargs):
         logger.info(f'Stored validated name {payload["given_name"]} {payload["family_name"]}')
 
     access_token = kwargs.get('access_token', None)
-    headers = {
-        'Accept': 'application/json, application/json;charset=UTF-8',
-        'Authorization': f'Bearer {access_token}',
-    }
-    response = requests.get(f'{settings.EDUID_API_BASE_URL}/myconext/api/eduid/links', headers=headers, timeout=60)
-    if response.status_code != 200:
-        error = f'Server error: eduID eppn endpoint error ({response.status_code})'
+    
+    oidc_client = OidcClient.get_client_from_settings()
+    try:
+        userinfo = oidc_client.get_userinfo(access_token)
+    except Exception as e:
+        error = f'Server error: {e}'
         logger.debug(error)
         return render_authentication_error(request, EduIDProvider.id, error=error)
-    eppn_json = response.json()
+
     request.user.clear_affiliations()
-    for info in eppn_json: 
-        if 'eppn' in info and 'schac_home_organization' in info: # Is ingeschreven bij instituut
+    if userinfo.eppn() and userinfo.schac_home_organization():  # Is ingeschreven bij instituut
             request.user.add_affiliations(
                 [
                     {
-                        'eppn': info['eppn'].lower(),
-                        'schac_home': info['schac_home_organization'],
+                        'eppn': userinfo.eppn(),
+                        'schac_home': userinfo.schac_home_organization(),
                     }
                 ]
             )
-            logger.info(f'Stored affiliations {info["eppn"]} {info["schac_home_organization"]}')
-    validated_names = [info['validated_name'] for info in eppn_json if 'validated_name' in info]
-    if request.user.validated_name and len(validated_names) == 0: # Validated name was set above, but the myconext endpoint does not return any validated names
+            logger.info(f'Stored affiliations {userinfo.eppn()} {userinfo.schac_home_organization()}')
+
+    if request.user.validated_name and not userinfo.has_validated_name():
         ret = HttpResponseRedirect(ret.url + '&revalidate-name=true')
-    if len(validated_names) > 0:
+
+    if userinfo.has_validated_name():
         val_name_audit_trail_signal.send(
             sender=request.user.__class__,
             user=request.user,
             old_validated_name=request.user.validated_name,
-            new_validated_name=validated_names[0],
+            new_validated_name=userinfo.validated_name()
         )
-        request.user.validated_name = validated_names[0] # Override with validated name from myconext endpoint
+        request.user.validated_name = userinfo.validated_name()
     else:
         val_name_audit_trail_signal.send(
             sender=request.user.__class__,

--- a/apps/badgrsocialauth/views.py
+++ b/apps/badgrsocialauth/views.py
@@ -50,7 +50,7 @@ class BadgrSocialLogin(RedirectView):
             raise ValidationError('Unable to save BadgrApp in session')
 
         try:
-            redirect_url = reverse('{}_login'.format(self.request.GET.get('provider')))
+            redirect_url = reverse('{}_login'.format(provider_name))
         except NoReverseMatch:
             raise ValidationError('No {} provider found'.format(provider_name))
         authcode = self.request.GET.get('authCode', None)

--- a/apps/mainsite/settings.py
+++ b/apps/mainsite/settings.py
@@ -336,6 +336,12 @@ if DOMAIN.startswith('acc') or DOMAIN.startswith('www'):
     }
     debug_handlers.append('badgr_debug_loki')
 
+# Dev and Test use console logging and never loki or file-logging
+# Django appears to have no common way to determine if it is running in dev/test mode, so we
+# hack around this by checking if the server name is localhost.
+if SERVER_NAME == 'localhost':
+    debug_handlers = ['badgr_debug_console']
+
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,

--- a/apps/mainsite/settings.py
+++ b/apps/mainsite/settings.py
@@ -198,6 +198,17 @@ SOCIALACCOUNT_EMAIL_VERIFICATION = 'mandatory'
 SOCIALACCOUNT_ADAPTER = 'badgrsocialauth.adapter.BadgrSocialAccountAdapter'
 
 SURFCONEXT_DOMAIN_URL = os.environ.get('SURFCONEXT_DOMAIN_URL', 'https://connect.test.surfconext.nl/oidc')
+
+## 
+# EduId, in both provider and EDUID_xxx (or EDU_ID) is a confusing name, because it's really surfconext but the surfconext setup for the students.
+# A better name would be something like OIDC_STUDENT_xxx but that would be a big change as we'd need to rename socialauth providers, 
+# urls, views, and database migrations.
+
+# Determines the subclass of the oidc client to use. Can be 'eduid' or 'surfconext'.
+# When "eduid" is used, we *must* set the EDUID_API_BASE_URL, as this is used to build the URL
+# that mimics the "userinfo" endpoint of the oidc client but has "validated name" information.
+# For surfconext, the userinfo endpoint is determined from the SURFCONEXT_DOMAIN_URL.
+EDUID_OIDC_PROVIDER_NAME = 'surfconext'
 EDUID_PROVIDER_URL = os.environ['EDUID_PROVIDER_URL']
 EDUID_API_BASE_URL = os.environ.get('EDUID_API_BASE_URL', 'https://login.test.eduid.nl')
 EDUID_IDENTIFIER = os.environ.get('EDUID_IDENTIFIER', 'eduid')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - DEFAULT_FROM_EMAIL=noreply@surf.nl
       - DOMAIN=0.0.0.0:8000
       - EDUID_PROVIDER_URL=https://connect.test.surfconext.nl/oidc
-      - EDU_ID_CLIENT=edubadges
+      - EDU_ID_CLIENT=ewi.backpack.edubadges
       - EDU_ID_SECRET=${EDU_ID_SECRET}
       - EMAIL_HOST=mailhog
       - EMAIL_PORT=1025

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - EDUID_PROVIDER_URL=https://connect.test.surfconext.nl/oidc
       - EDU_ID_CLIENT=ewi.backpack.edubadges
       - EDU_ID_SECRET=${EDU_ID_SECRET}
+      - EDUID_IDENTIFIER=sub
       - EMAIL_HOST=mailhog
       - EMAIL_PORT=1025
       - LTI_FRONTEND_URL=localhost


### PR DESCRIPTION
feat: Allow generic surfconext as authz handler
Our edu_id was tightly coupled to a private API in edu_id, that is only
available if we have an actual eduID. Our IDP doesn't have this.

Therefore we:
- use the sub, not the edu_id for storing and finding the socialaccount
- have configuration that allows edu_id and generic handler and wrappers
  to determine validated_name attributes and other attributes. EduId
  fetches it from the private API, as before, surfconext fetches it from
  userinfo endpoint and then fakes the validated_name check.
- use polymorphic classes to handle the internals, rather than large
  if/else codebranches