### PR TITLE
feat: Add expires_at that is required with new impierce version

### DIFF
--- a/apps/ob3/api.py
+++ b/apps/ob3/api.py
@@ -13,8 +13,8 @@ from pprint import pformat
 
 from issuer.models import BadgeInstance
 from mainsite.settings import OB3_AGENT_URL_SPHEREON, OB3_AGENT_AUTHZ_TOKEN_SPHEREON, OB3_AGENT_URL_UNIME
-from .serializers import OfferRequestSerializer
-from .models import OfferRequest
+from .serializers import ImpierceOfferRequestSerializer
+from .models import ImpierceOfferRequest
 
 logger = logging.getLogger('django')
 
@@ -32,20 +32,15 @@ class CredentialsView(APIView):
 
         badge_instance = self.__badge_instance(badge_id, request.user)
         logger.debug(f"Badge instance: {pformat(badge_instance.__dict__)}")
-        credential_configuration_id = {
-            'sphereon': "OpenBadgeCredential",
-            'unime': "openbadge_credential"
-        }.get(variant) 
-        credential = OfferRequest(offer_id, credential_configuration_id, badge_instance)
-        serializer = OfferRequestSerializer(credential)
 
-        if variant == 'sphereon':
-            offer = self.__issue_sphereon_badge(serializer.data)
-            logger.debug(f"Sphereon offer: {offer}")
-        elif variant == 'unime':
+        if variant == 'unime':
+            credential = ImpierceOfferRequest(offer_id, "openbadge_credential", badge_instance)
+            serializer = ImpierceOfferRequestSerializer(credential)
             self.__issue_unime_badge(serializer.data)
             offer = self.__get_unime_offer(offer_id)
             logger.debug(f"Unime offer: {offer}")
+        else:
+            raise BadRequest("variant not supported. We only support unime")
 
         logger.info(f"Issued credential for badge {badge_id} with offer_id {offer_id}")
         logger.debug(f"Credential: {pformat(serializer.data)}")

--- a/apps/ob3/models.py
+++ b/apps/ob3/models.py
@@ -51,13 +51,14 @@ class StructFieldsMixin:
             setattr(self, key, value)
 
 # A plain old Python object (POPO) that represents an educational credential
-class OfferRequest:
+class ImpierceOfferRequest:
     def __init__(self, offer_id, credential_configuration_id, badge_instance):
         self.offer_id = offer_id
         self.credential_configuration_id = credential_configuration_id
 
         credential_subject = AchievementSubject.from_badge_instance(badge_instance)
         self.credential = Credential(
+            entity_id=badge_instance.entity_id,
             issuer=badge_instance.badgeclass.issuer,
             valid_from = badge_instance.issued_on,
             credential_subject=credential_subject,
@@ -69,8 +70,32 @@ class OfferRequest:
         else:
             self.expires_at = "never"
 
+class SphereonOfferRequest:
+    def __init__(self, offer_id, credential_configuration_id, badge_instance, edu_id, email, eppn, family_name, given_name):
+        self.credential_configuration_ids = [credential_configuration_id]
+        self.grants = {
+            "authorization_code": {
+                "issuer_state": offer_id,
+            }
+        }
+        credential_subject = AchievementSubject.from_badge_instance(badge_instance)
+        self.credential = Credential(
+            entity_id=badge_instance.entity_id,
+            issuer=badge_instance.badgeclass.issuer,
+            valid_from=badge_instance.issued_on,
+            credential_subject=credential_subject,
+        )
+        # TODO: Sphereon doesn't seem to support expiration dates yet, so we don't set it here.
+
+        self.edu_id = edu_id
+        self.email = email
+        self.eppn = eppn
+        self.family_name = family_name
+        self.given_name = given_name
+
 class Credential:
-    def __init__(self, issuer, valid_from, credential_subject, **kwargs):
+    def __init__(self, entity_id, issuer, valid_from, credential_subject, **kwargs):
+        self.id = entity_id
         self.issuer = issuer
         self.valid_from = valid_from
         self.credential_subject = credential_subject

--- a/apps/ob3/models.py
+++ b/apps/ob3/models.py
@@ -65,10 +65,10 @@ class ImpierceOfferRequest:
         )
 
         if badge_instance.expires_at:
-            self.expires_at = badge_instance.expires_at.strftime("%Y-%m-%dT%H:%M:%SZ")
+            self.expires_at = badge_instance.expires_at
             self.credential.valid_until = badge_instance.expires_at
         else:
-            self.expires_at = "never"
+            self.expires_at = None
 
 class SphereonOfferRequest:
     def __init__(self, offer_id, credential_configuration_id, badge_instance, edu_id, email, eppn, family_name, given_name):

--- a/apps/ob3/models.py
+++ b/apps/ob3/models.py
@@ -64,7 +64,10 @@ class OfferRequest:
         )
 
         if badge_instance.expires_at:
+            self.expires_at = badge_instance.expires_at
             self.credential.valid_until = badge_instance.expires_at
+        else:
+            self.expires_at = "never"
 
 class Credential:
     def __init__(self, issuer, valid_from, credential_subject, **kwargs):

--- a/apps/ob3/models.py
+++ b/apps/ob3/models.py
@@ -65,7 +65,7 @@ class ImpierceOfferRequest:
         )
 
         if badge_instance.expires_at:
-            self.expires_at = badge_instance.expires_at
+            self.expires_at = badge_instance.expires_at.strftime("%Y-%m-%dT%H:%M:%SZ")
             self.credential.valid_until = badge_instance.expires_at
         else:
             self.expires_at = "never"

--- a/apps/ob3/serializers.py
+++ b/apps/ob3/serializers.py
@@ -209,9 +209,5 @@ class SphereonOfferRequestSerializer(serializers.Serializer):
 class ImpierceOfferRequestSerializer(serializers.Serializer):
     offerId = serializers.CharField(source='offer_id')
     credentialConfigurationId = serializers.CharField(source='credential_configuration_id')
-    expiresAt = serializers.DateTimeField(
-            source='expires_at',
-            required=True,
-            default_timezone=timezone.utc
-    )
+    expiresAt = serializers.CharField(source='expires_at', required=True)
     credential = CredentialSerializer()

--- a/apps/ob3/serializers.py
+++ b/apps/ob3/serializers.py
@@ -187,4 +187,8 @@ class CredentialSerializer(OmitNoneFieldsMixin, serializers.Serializer):
 class OfferRequestSerializer(serializers.Serializer):
     offerId = serializers.CharField(source='offer_id')
     credentialConfigurationId = serializers.CharField(source='credential_configuration_id')
+    expires_at = serializers.DateTimeField(
+            required=True,
+            default_timezone=timezone.utc
+    )
     credential = CredentialSerializer()

--- a/apps/ob3/serializers.py
+++ b/apps/ob3/serializers.py
@@ -211,3 +211,12 @@ class ImpierceOfferRequestSerializer(serializers.Serializer):
     credentialConfigurationId = serializers.CharField(source='credential_configuration_id')
     expiresAt = serializers.CharField(source='expires_at', required=True)
     credential = CredentialSerializer()
+
+    def to_representation(self, instance):
+        ret = super().to_representation(instance)
+        if instance.expires_at:
+            ret['expiresAt'] = instance.expires_at.strftime('%Y-%m-%dT%H:%M:%SZ')
+        else:
+            ret['expiresAt'] = "never"
+            
+        return ret

--- a/apps/ob3/serializers.py
+++ b/apps/ob3/serializers.py
@@ -169,6 +169,7 @@ class AchievementSubjectSerializer(OmitNoneFieldsMixin, serializers.Serializer):
 class CredentialSerializer(OmitNoneFieldsMixin, serializers.Serializer):
     OMIT_IF_NONE = ['validFrom', 'validUntil']
 
+    id = serializers.URLField()
     issuer = IssuerSerializer()
     validFrom = serializers.DateTimeField(
             source='valid_from',
@@ -184,10 +185,32 @@ class CredentialSerializer(OmitNoneFieldsMixin, serializers.Serializer):
     )
     credentialSubject = AchievementSubjectSerializer(source='credential_subject')
 
-class OfferRequestSerializer(serializers.Serializer):
+    def to_representation(self, instance):
+        ret = super().to_representation(instance)
+        # TODO: Decide how to handle public vs private assertions: the latter won't resolve
+        # TODO: DRY the id-to-url conversion
+        """Convert the id to a URL"""
+        ret['id'] = f"{UI_URL}/public/assertions/{ret['id']}"
+
+        return ret
+
+class SphereonOfferRequestSerializer(serializers.Serializer):
+    credential_configuration_ids = serializers.ListField()
+    grants = serializers.DictField()
+
+    credentialData = CredentialSerializer(source='credential')
+
+    eduId = serializers.CharField(source='edu_id')
+    email = serializers.EmailField()
+    eppn = serializers.EmailField()
+    familyName = serializers.CharField(source='family_name')
+    givenName = serializers.CharField(source='given_name')
+
+class ImpierceOfferRequestSerializer(serializers.Serializer):
     offerId = serializers.CharField(source='offer_id')
     credentialConfigurationId = serializers.CharField(source='credential_configuration_id')
-    expires_at = serializers.DateTimeField(
+    expiresAt = serializers.DateTimeField(
+            source='expires_at',
             required=True,
             default_timezone=timezone.utc
     )

--- a/apps/ob3/tests.py
+++ b/apps/ob3/tests.py
@@ -3,8 +3,8 @@ from django.test import SimpleTestCase
 
 from datetime import datetime as DateTime
 
-from .models import OfferRequest, IdentityObject
-from .serializers import OfferRequestSerializer
+from .models import ImpierceOfferRequest as OfferRequest, IdentityObject
+from .serializers import ImpierceOfferRequestSerializer as OfferRequestSerializer
 
 from  mainsite.settings import UI_URL
 
@@ -206,6 +206,7 @@ class TestCredentialsSerializers(SimpleTestCase):
         self.assertIn(expected_alignment, actual_data["alignment"])
 
     def _serialize_it(self, badge_instance: BadgeInstanceMock):
+       # TODO: We should test both impierce and sphereon models and serializers
        edu_credential = OfferRequest("offer_id", "credential_configuration_id", badge_instance)
        return dict(OfferRequestSerializer(edu_credential).data)
 

--- a/apps/ob3/tests.py
+++ b/apps/ob3/tests.py
@@ -54,6 +54,7 @@ class TestCredentialsSerializers(SimpleTestCase):
 
         expected_data = {
             "offerId": "offer_id",
+            "expires_at": "never",
             "credentialConfigurationId": "credential_configuration_id",
             "credential": {
                 "issuer": {
@@ -118,6 +119,20 @@ class TestCredentialsSerializers(SimpleTestCase):
         actual_data = self._serialize_it(badge_instance)
 
         self.assertEqual(actual_data["credential"]["validUntil"], "2020-01-01T01:13:37Z")
+
+    def test_impierce_offer_request_expires_at(self):
+        badge_instance = BadgeInstanceMock()
+        badge_instance.expires_at = DateTime.fromisoformat("2020-01-01:01:13:37")
+        actual_data = self._serialize_it(badge_instance)
+
+        self.assertEqual(actual_data["expires_at"], "2020-01-01T01:13:37Z")
+
+    def test_impierce_offer_request_expires_at_notset(self):
+        badge_instance = BadgeInstanceMock()
+        badge_instance.expires_at = None
+        actual_data = self._serialize_it(badge_instance)
+
+        self.assertEqual(actual_data["expires_at"], "never")
 
     def test_education_language_extension(self):
         badge_instance = BadgeInstanceMock()

--- a/apps/ob3/tests.py
+++ b/apps/ob3/tests.py
@@ -51,12 +51,12 @@ class TestCredentialsSerializers(SimpleTestCase):
     def test_serializer_serializes_credential(self):
         badge_instance = BadgeInstanceMock()
         actual_data = self._serialize_it(badge_instance)
-
         expected_data = {
             "offerId": "offer_id",
-            "expires_at": "never",
+            "expiresAt": "never",
             "credentialConfigurationId": "credential_configuration_id",
             "credential": {
+                "id": f"{UI_URL}/public/assertions/BADGE1234",
                 "issuer": {
                     "id": f"{UI_URL}/ob3/issuers/ISS1234",
                     "type": ["Profile"],
@@ -125,14 +125,14 @@ class TestCredentialsSerializers(SimpleTestCase):
         badge_instance.expires_at = DateTime.fromisoformat("2020-01-01:01:13:37")
         actual_data = self._serialize_it(badge_instance)
 
-        self.assertEqual(actual_data["expires_at"], "2020-01-01T01:13:37Z")
+        self.assertEqual(actual_data["expiresAt"], "2020-01-01T01:13:37Z")
 
     def test_impierce_offer_request_expires_at_notset(self):
         badge_instance = BadgeInstanceMock()
         badge_instance.expires_at = None
         actual_data = self._serialize_it(badge_instance)
 
-        self.assertEqual(actual_data["expires_at"], "never")
+        self.assertEqual(actual_data["expiresAt"], "never")
 
     def test_education_language_extension(self):
         badge_instance = BadgeInstanceMock()

--- a/apps/ob3/tests/__init__.py
+++ b/apps/ob3/tests/__init__.py
@@ -1,0 +1,1 @@
+from .tests import *

--- a/apps/ob3/tests/tests.py
+++ b/apps/ob3/tests/tests.py
@@ -3,8 +3,8 @@ from django.test import SimpleTestCase
 
 from datetime import datetime as DateTime
 
-from .models import ImpierceOfferRequest as OfferRequest, IdentityObject
-from .serializers import ImpierceOfferRequestSerializer as OfferRequestSerializer
+from apps.ob3.models import ImpierceOfferRequest as OfferRequest, IdentityObject
+from apps.ob3.serializers import ImpierceOfferRequestSerializer as OfferRequestSerializer
 
 from  mainsite.settings import UI_URL
 


### PR DESCRIPTION
We are updating impierce agent to their latest "beta" version. They now require an "expires_at" attribute when requesting a credential in the API call. This can be set to either "never" or to a datetime string. 

Once we have updated the impierce agent on the poc server, the demo will no longer be able to issue impierce OBV3 credentials without this change. 

It is ok to send it along to the old - not yet upgraded impierce agent, so no problem merging this before the agent is upgraded. 

Upgrade is planned for next week.