### PR TITLE
chore: Debug log printed confusing log entries

### DIFF
--- a/apps/badgrsocialauth/providers/eduid/oidc_client.py
+++ b/apps/badgrsocialauth/providers/eduid/oidc_client.py
@@ -39,7 +39,7 @@ class OidcClient:
         }
         logger.debug(f'Calling userinfo endpoint {self._userinfo_endpoint}')
         response = requests.get(self._userinfo_endpoint, headers=headers)
-        logger.debug(f'Userinfo endpoint response {response}')
+        logger.debug(f'Userinfo response - Status Code: {response.status_code}, Headers: {dict(response.headers)}, Content: {response.text}')
         if response.status_code != 200:
             raise Exception(f'User info endpoint error (http {response.status_code}). Try alternative login methods')
 

--- a/apps/badgrsocialauth/providers/eduid/views.py
+++ b/apps/badgrsocialauth/providers/eduid/views.py
@@ -113,10 +113,11 @@ def callback(request):
         headers=headers,
         timeout=60,
     )
-    logger.debug(f'Token response: {token_response}')
+    
+    logger.debug(f'Token response - Status Code: {token_response.status_code}, Headers: {dict(token_response.headers)}, Content: {token_response.text}')
     if token_response.status_code != 200:
         error = (
-            'Server error: User info endpoint error (http %s). Try alternative login methods'
+            'Server error: Token endpoint error (http %s). Try alternative login methods'
             % token_response.status_code
         )
         logger.error(error)


### PR DESCRIPTION
While debugging a problem in the OIDC flow, debug logs printed wrong prefixes: userinfo instead of the actual token exchange.

The details in that log were not useful either. "<Response<401>>" rather than the actual response content and headers that contained the details on why it failed.