### PR TITLE
chore: Add type stubs for Django and rest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,9 @@ RUN pip install --upgrade pip setuptools wheel
 # Install any needed packages specified in requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Install development dependencies
+RUN pip install --system --no-cache -r requirements-dev.txt
+
 # Make port 8000 available to the world outside this container
 EXPOSE 8000
 

--- a/README.md
+++ b/README.md
@@ -152,8 +152,10 @@ _from within edubadges-server directory_
 
 - `pip install -r requirements.txt`
 
-if on a mac mysqlclient does not build, try:
+For development, also install development dependencies:
+- `pip install -r requirements-dev.txt`
 
+if on a mac mysqlclient does not build, try:
 ```
 LDFLAGS=-L/usr/local/opt/openssl/lib pip install mysqlclient
 ```

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+# Development dependencies
+django-stubs==5.1.3  # 5.x is mostly backwards compatible with Django 4.2, see https://github.com/typeddjango/django-stubs/discussions/2101.
+django-stubs-ext==5.1.3
+djangorestframework-stubs==3.15.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ drf_spectacular_sidecar==2025.2.1
 
 django-object-actions==4.3.0
 
-pymemcache==4.0.0 
+pymemcache==4.0.0
 
 djangorestframework==3.15.2
 django-filter==25.1


### PR DESCRIPTION
This "fixes" several hundreds of typing errors and warnings. Leaving us with several hundred of relevant warnings and about fifty relevant and potentially problematic errors.

Backported from feature/ewi

Add development dependencies and installation instructions

Add requirements-dev.txt with type stubs for Django and DRF Update installation docs in README, Dockerfile and
Include dev dependencies installation step in all relevant docs