### PR TITLE
fix: Remove SURF institution filter from badge counts

### DIFF
--- a/apps/issuer/schema.py
+++ b/apps/issuer/schema.py
@@ -407,14 +407,11 @@ class Query(object):
             return []
         return list(filter(lambda bi: bi.revoked == True, user.cached_badgeinstances()))
 
-    def resolve_badge_instances_count(self, info):
-        surf_institution = BadgeClass.objects.get(name=settings.EDUID_BADGE_CLASS_NAME).issuer.faculty.institution
+    def resolve_badge_instances_count(self, _):
         today = datetime.utcnow()
-        query = BadgeInstance.objects.exclude(badgeclass__issuer__faculty__institution=surf_institution).exclude(
-            expires_at__lte=today)
+        query = BadgeInstance.objects.exclude(expires_at__lte=today)
         return query.count()
 
-    def resolve_badge_classes_count(self, info):
-        surf_institution = BadgeClass.objects.get(name=settings.EDUID_BADGE_CLASS_NAME).issuer.faculty.institution
-        query = BadgeClass.objects.exclude(issuer__faculty__institution=surf_institution)
+    def resolve_badge_classes_count(self, _):
+        query = BadgeClass.objects.exclude()
         return query.count()


### PR DESCRIPTION
In commit b46fa93f, the `resolve_badge_instances_count` and `resolve_badge_classes_count` methods were updated to exclude badges with the name `settings.EDUID_BADGE_CLASS_NAME`. However, in commit 7378b90d, the creation of the badge class with this name was removed from the seed file. This means the badge class no longer exists in the database, letting the `get` query fail with a "not found" exception.

This lead to the graphql query failing:
```json
{
"errors": [
{
"message": "BadgeClass matching query does not exist.", "locations": [
{
"line": 2,
"column": 11
}
],
"path": [
"badgeInstancesCount"
]
},
{
"message": "BadgeClass matching query does not exist.", "locations": [
{
"line": 3,
"column": 11
}
],
"path": [
"badgeClassesCount"
]
}
]
}```