### PR TITLE
fix: Remove stale "make edubadge public" text from notification emails

### DIFF
--- a/apps/mainsite/templates/email/earned_badge.html
+++ b/apps/mainsite/templates/email/earned_badge.html
@@ -133,7 +133,6 @@
     <p class="text text_header">Bekijk jouw edubadge.</p>
     <p class="text">
         Het plaatje hierboven is een voorbeeld, de echte gepersonaliseerde edubadge is beschikbaar in jouw backpack.
-        <br /><br />Denk eraan om je edubadge publiek te zetten als je deze wilt delen met anderen.
     </p>
     <a class="button" target="_blank" rel="noopener noreferrer" href="{{assertion_url}}"> Bekijk jouw edubadge</a>
 </div>

--- a/apps/mainsite/templates/email/earned_direct_award.html
+++ b/apps/mainsite/templates/email/earned_direct_award.html
@@ -128,8 +128,7 @@
     <p class="text">{{badgeclass_description}}</p> -->
 
     <p class="text text_header">Bekijk jouw edubadge.</p>
-    <p class="text">Het plaatje hierboven is een voorbeeld, de echte gepersonaliseerde edubadge kun je claimen in je backpack.
-        <br><br>Denk eraan om je edubadge publiek te zetten als je deze wilt delen met anderen.</p>
+    <p class="text">Het plaatje hierboven is een voorbeeld, de echte gepersonaliseerde edubadge kun je claimen in je backpack.</p>
     <a class="button" target="_blank" rel="noopener noreferrer" href="{{ui_url}}">
         Claim deze edubadge in je backpack</a>
 </div>


### PR DESCRIPTION
The "public badge" sharing feature was removed in 95d3b402 and re-removed after a merge conflict in 39bd1263, but the instruction to make a badge public before sharing was overlooked in earned_badge.html and earned_direct_award.html

This fixes https://git.ia.surfsara.nl/surf-internal/educational-logistics/edubadges/edubadges/-/issues/86