### PR TITLE
Refactor badge extension validator to remove dependency on openbadges

### DIFF
--- a/apps/mainsite/validators.py
+++ b/apps/mainsite/validators.py
@@ -1,9 +1,9 @@
 # encoding: utf-8
 
-import openbadges.verifier
 from rest_framework.exceptions import ValidationError
-
 from mainsite.utils import verify_svg
+import requests
+from jsonschema import validate, ValidationError as JsonSchemaValidationError
 
 
 class ValidImageValidator(object):
@@ -25,19 +25,79 @@ class ValidImageValidator(object):
                     raise ValidationError('Invalid PNG')
 
 
-class BadgeExtensionValidator(object):
+
+class SimpleExtensionValidator:
+    def __init__(self, cache=None):
+        self.cache = cache or {}
+
+    def fetch_schema(self, url):
+        if url in self.cache:
+            return self.cache[url]
+
+        response = requests.get(url, timeout=5)
+        response.raise_for_status()
+        schema = response.json()
+        self.cache[url] = schema
+        return schema
+
+    def validate(self, extension_input):
+        errors = []
+
+        context = extension_input.get("@context", {})
+        validations = context.get("obi:validation", [])
+
+        if not validations:
+            return {
+                "valid": False,
+                "messages": ["No validation rules found in context"]
+            }
+
+        for rule in validations:
+            ext_type = rule.get("obi:validatesType")
+            schema_url = rule.get("obi:validationSchema")
+
+            if not ext_type or not schema_url:
+                errors.append("Invalid validation rule in context")
+                continue
+
+            # Extract extension key (e.g. "ECTS")
+            short_name = ext_type.split(":")[-1].replace("Extension", "")
+
+            if short_name not in extension_input:
+                errors.append(f"Missing extension field: {short_name}")
+                continue
+
+            try:
+                schema = self.fetch_schema(schema_url)
+
+                validate(
+                    instance={short_name: extension_input[short_name]},
+                    schema=schema
+                )
+
+            except JsonSchemaValidationError as e:
+                errors.append(f"{short_name}: {e.message}")
+
+            except Exception as e:
+                errors.append(f"Schema fetch/validation failed: {str(e)}")
+
+        return {
+            "valid": len(errors) == 0,
+            "messages": errors
+        }
+
+
+class BadgeExtensionValidator:
     message = "Invalid OpenBadges Extension"
+
+    def __init__(self):
+        self.validator = SimpleExtensionValidator()
 
     def __call__(self, value):
         if len(value) > 0:
-            options = {"use_cache": True, "cache_expire_after": 60 * 60 * 24,
-                       "jsonld_options": {"compactArrays": False}}
-            result = openbadges.verifier.validate_extensions(value.copy(), **options)
-            report = result.get('report', {})
-            if not report.get('valid', False):
-                messages = report.get('messages', [])
-                if len(messages) > 0:
-                    msg = [message.get('result', self.message) for message in messages]
-                else:
-                    msg = self.message
-                raise ValidationError(msg)
+            result = self.validator.validate(value.copy())
+
+            if not result["valid"]:
+                raise ValidationError(
+                    result["messages"] or self.message
+                )


### PR DESCRIPTION
FIRST MERGE #343 !

This PR removes the need for the openbadges.verifier. I refactored the verification process to simply validate the json schema and types, instead of expecting the openbadges specific structure report etc.

This new validator is a trimmed down version, but we don't need the full functionality anymore, because we don't have to support other badges than the ones we create and we don't need to support baked images anymore. This makes everything easier.