### PR TITLE
Feature/ewi creator

### DIFF
--- a/apps/ob3/models.py
+++ b/apps/ob3/models.py
@@ -6,7 +6,7 @@ from typing import Optional
 from urllib.parse import urljoin
 
 import requests
-from issuer.models import BadgeInstance
+from issuer.models import BadgeInstance, Issuer
 from ob3.serializers import ImpierceOfferRequestSerializer, SphereonOfferRequestSerializer, VeramoOfferRequestSerializer
 from typing_extensions import override
 
@@ -228,10 +228,7 @@ class VeramoOfferRequest(OfferRequest):
         Returns:
             The response text from the HTTP call containing the offer URI
         """
-        headers = {
-            'Accept': 'application/json',
-            'Authorization': f'Bearer {self._get_authz_token()}'
-        }
+        headers = {'Accept': 'application/json', 'Authorization': f'Bearer {self._get_authz_token()}'}
 
         payload = VeramoOfferRequestSerializer(self).data
 
@@ -250,10 +247,49 @@ class VeramoOfferRequest(OfferRequest):
         return offer_uri
 
 
+class Creator:
+    def __init__(self, entity_id: str, name: str, image: dict[str, str], parent_org: Optional['Creator'] = None):
+        self.id: str = entity_id
+        self.name: str = name
+        self.image: dict[str, str] = image
+        self.parent_org: Optional['Creator'] = parent_org
+
+    @staticmethod
+    def from_issuer(issuer: Issuer) -> 'Creator':
+        faculty = issuer.faculty
+        institution = faculty.institution
+
+        instiution_profile = Creator(
+            entity_id=institution.entity_id,
+            name=institution.name,
+            image={'id': institution.image_url()},
+            parent_org=None,
+        )
+        faculty_profile = Creator(
+            entity_id=faculty.entity_id,
+            name=faculty.name,
+            image={'id': faculty.image_url()},
+            parent_org=instiution_profile,
+        )
+
+        return faculty_profile
+
+
+class CredentialIssuer:
+    def __init__(self, entity_id: str, name: str, image: dict[str, str]):
+        self.id: str = entity_id
+        self.name: str = name
+        self.image: dict[str, str] = image
+
+    @staticmethod
+    def from_issuer(issuer: Issuer) -> 'CredentialIssuer':
+        return CredentialIssuer(entity_id=issuer.entity_id, name=issuer.name, image={'id': issuer.image_url()})
+
+
 class Credential:
     def __init__(self, entity_id, issuer, valid_from, credential_subject, **kwargs):
         self.id = entity_id
-        self.issuer = issuer
+        self.issuer = CredentialIssuer.from_issuer(issuer)
         self.valid_from = valid_from
         self.credential_subject = credential_subject
 
@@ -299,6 +335,7 @@ class IdentityObject:
 class Achievement(StructFieldsMixin):
     FIELDS = [
         'id',
+        'creator',
         'criteria',
         'description',
         'ects',
@@ -313,6 +350,7 @@ class Achievement(StructFieldsMixin):
     @staticmethod
     def from_badge_instance(badge_instance: BadgeInstance) -> 'Achievement':
         badge_class = badge_instance.badgeclass
+        creator = Creator.from_issuer(badge_class.issuer)
         in_language = None
         ects = None
         education_program_identifier = None
@@ -330,6 +368,7 @@ class Achievement(StructFieldsMixin):
 
         return Achievement(
             id=badge_instance.entity_id,
+            creator=creator,
             criteria={'narrative': badge_class.criteria_text},
             description=badge_class.description,
             name=badge_class.name,

--- a/apps/ob3/models.py
+++ b/apps/ob3/models.py
@@ -259,7 +259,7 @@ class Creator:
         faculty = issuer.faculty
         institution = faculty.institution
 
-        instiution_profile = Creator(
+        institution_profile = Creator(
             entity_id=institution.entity_id,
             name=institution.name,
             image={'id': institution.image_url()},
@@ -269,7 +269,7 @@ class Creator:
             entity_id=faculty.entity_id,
             name=faculty.name,
             image={'id': faculty.image_url()},
-            parent_org=instiution_profile,
+            parent_org=institution_profile,
         )
 
         return faculty_profile

--- a/apps/ob3/models.py
+++ b/apps/ob3/models.py
@@ -13,7 +13,7 @@ from typing_extensions import override
 logger = logging.getLogger('django')
 
 
-def generate_sha256_hashstring(identifier: str, salt: Optional[str] = None):
+def generate_sha256_hashstring(identifier: str, salt: Optional[str] = None) -> str:
     """
     Generate a SHA-256 hash string from an identifier and salt.
     This is now exactly the same as the one in issuer/utils, but that's accidental
@@ -285,14 +285,14 @@ class IdentityObject:
     but contrary to all other "objects" in the OBv3 spec, it's what the spec calls it.
     """
 
-    def __init__(self, recipient_identifier, salt, hasher=generate_sha256_hashstring):
-        self.identity_hash = hasher(recipient_identifier, salt)
-        self.identity_type = 'emailAddress'
-        self.hashed = True
-        self.salt = salt
+    def __init__(self, recipient_identifier: str, salt: str, hasher=generate_sha256_hashstring):
+        self.identity_hash: str = hasher(recipient_identifier, salt)
+        self.identity_type: str = 'emailAddress'
+        self.hashed: bool = True
+        self.salt: str = salt
 
     @staticmethod
-    def from_badge_instance(badge_instance):
+    def from_badge_instance(badge_instance: BadgeInstance):
         return IdentityObject(badge_instance.recipient_identifier, badge_instance.salt)
 
 

--- a/apps/ob3/serializers.py
+++ b/apps/ob3/serializers.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 from django.utils import timezone
 from mainsite.settings import UI_URL
@@ -20,7 +20,7 @@ class OmitNoneFieldsMixin:
 
     OMIT_IF_NONE = []
 
-    def to_representation(self, instance: Any) -> Dict[str, Any]:
+    def to_representation(self, instance: Any) -> dict[str, Any]:
         # Juggling to call the parent's to_representation method and not raise type errors
         def fallback_to_representation(x):
             return dict(x.__dict__)
@@ -34,21 +34,24 @@ class OmitNoneFieldsMixin:
         return representation
 
 
-class IssuerSerializer(serializers.Serializer):
+class ImageSerializer(serializers.Serializer):
+    type = serializers.CharField(read_only=True, default='Image')
+    id = serializers.URLField()
+
+
+class IssuerSerializer(OmitNoneFieldsMixin, serializers.Serializer):
+    OMIT_IF_NONE = ['image']
+
     id = serializers.URLField()
     type = serializers.ListField(child=serializers.CharField(), read_only=True, default=['Profile'])
     name = serializers.CharField()
+    image = ImageSerializer(allow_null=True)
 
     def to_representation(self, instance):
         ret = super().to_representation(instance)
         """Convert the id to a URL"""
         ret['id'] = f'{UI_URL}/ob3/issuers/{ret["id"]}'
         return ret
-
-
-class ImageSerializer(serializers.Serializer):
-    type = serializers.CharField(read_only=True, default='Image')
-    id = serializers.URLField()
 
 
 class AlignmentSerializer(serializers.Serializer):

--- a/apps/ob3/serializers.py
+++ b/apps/ob3/serializers.py
@@ -1,7 +1,6 @@
 from typing import Any
 
 from django.utils import timezone
-import institution
 from mainsite.settings import UI_URL
 from rest_framework import serializers
 

--- a/apps/ob3/serializers.py
+++ b/apps/ob3/serializers.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from django.utils import timezone
+import institution
 from mainsite.settings import UI_URL
 from rest_framework import serializers
 
@@ -53,6 +54,38 @@ class IssuerSerializer(OmitNoneFieldsMixin, serializers.Serializer):
         ret['id'] = f'{UI_URL}/ob3/issuers/{ret["id"]}'
         return ret
 
+
+# Ideally, we'd re-use a more generic Profile Serializer, but for that we'd need
+# a complex and poorly maintained "Recursive field" serializer. Let's not go there.
+# Instead, we'll just hardcode the structure and make it explicit. That introduces
+# duplication, but also adds clarity.
+class InstitutionSerializer(OmitNoneFieldsMixin, serializers.Serializer):
+    OMIT_IF_NONE = ['image']
+
+    id = serializers.URLField()
+    type = serializers.ListField(child=serializers.CharField(), read_only=True, default=['Profile'])
+    name = serializers.CharField()
+    image = ImageSerializer(allow_null=True)
+
+    def to_representation(self, instance):
+        ret = super().to_representation(instance)
+        ret['id'] = f'{UI_URL}/public/institutions/{ret["id"]}'
+        return ret
+
+
+class CreatorSerializer(OmitNoneFieldsMixin, serializers.Serializer):
+    OMIT_IF_NONE = ['image', 'parentOrg']
+
+    type = serializers.ListField(child=serializers.CharField(), read_only=True, default=['Profile'])
+    id = serializers.URLField()
+    name = serializers.CharField()
+    image = ImageSerializer(allow_null=True)
+    parentOrg = InstitutionSerializer(allow_null=True, source='parent_org')
+
+    def to_representation(self, instance):
+        ret = super().to_representation(instance)
+        ret['id'] = f'{UI_URL}/public/faculties/{ret["id"]}'
+        return ret
 
 class AlignmentSerializer(serializers.Serializer):
     type = serializers.ListField(child=serializers.CharField(), read_only=True, default=['Alignment'])
@@ -117,6 +150,7 @@ class AchievementSerializer(OmitNoneFieldsMixin, serializers.Serializer):
         required=False,
         allow_null=True,
     )
+    creator = CreatorSerializer()
     ECTS = serializers.DecimalField(
         source='ects',
         decimal_places=1,

--- a/apps/ob3/tests/tests.py
+++ b/apps/ob3/tests/tests.py
@@ -9,6 +9,7 @@ from ob3.models import IdentityObject, ImpierceOfferRequest, VeramoOfferRequest
 from ob3.models import SphereonOfferRequest as SphereonOfferRequest
 from ob3.serializers import ImpierceOfferRequestSerializer as OfferRequestSerializer
 
+
 class BadgeClassMock:
     def __init__(self):
         self.criteria_text: str = 'You must Lorem Ipsum, **dolor** _sit_ amet'
@@ -36,7 +37,7 @@ class BadgeInstanceMock:
 
 class IssuerMock:
     def __init__(self):
-        self.id: str = 'ISS1234'
+        self.entity_id: str = 'ISS1234'
         self.name: str = 'Mock Issuer'
 
 
@@ -63,7 +64,12 @@ class TestCredentialsSerializers(SimpleTestCase):
             'credentialConfigurationId': 'credential_configuration_id',
             'credential': {
                 'id': f'{UI_URL}/public/assertions/BADGE1234',
-                'issuer': {'id': f'{UI_URL}/ob3/issuers/ISS1234', 'type': ['Profile'], 'name': 'Mock Issuer'},
+                'issuer': {
+                    'id': f'{UI_URL}/ob3/issuers/ISS1234',
+                    'type': ['Profile'],
+                    'name': 'Mock Issuer',
+                    'image': {'type': 'Image', 'id': 'https://example.com/images/issuers/mock.png'},
+                },
                 'credentialSubject': {
                     'type': ['AchievementSubject'],
                     'achievement': {
@@ -78,7 +84,7 @@ class TestCredentialsSerializers(SimpleTestCase):
             },
         }
 
-        self.maxDiff: Union[None, bool, int]  = None  # Debug full diff
+        self.maxDiff: Union[None, bool, int] = None  # Debug full diff
         self.assertDictEqual(actual_data, expected_data)
 
     def test_recipient(self):
@@ -98,13 +104,12 @@ class TestCredentialsSerializers(SimpleTestCase):
 
     def test_issuer(self):
         badge_instance = BadgeInstanceMock()
-        badge_instance.badgeclass.issuer.id = 'http://localhost:8080/ob3/issuers/ISS4567'
-        badge_instance.badgeclass.issuer.name = 'issuer name'
         actual_data = self._serialize_it(badge_instance)
         expected_issuer = {
-            'id': 'http://localhost:8080/ob3/issuers/ISS4567',
+            'id': 'http://localhost:8080/ob3/issuers/ISS1234',
             'type': ['Profile'],
-            'name': 'issuer name',
+            'name': 'Mock Issuer',
+            'image': {'type': 'Image', 'id': 'https://example.com/images/issuers/mock.png'},
         }
         self.assertEqual(actual_data['credential']['issuer'], expected_issuer)
 
@@ -363,11 +368,15 @@ class TestOfferRequestCallMethods(SimpleTestCase):
         offer_request.set_url('http://test-url.com')
 
         with patch('ob3.models.requests.post') as mock_post:
-            mock_response = type('MockResponse', (), {
-                'status_code': 200,
-                'text': '{"uri": "test-offer-uri"}',
-                'json': lambda self: {'uri': 'test-offer-uri'}
-            })()
+            mock_response = type(
+                'MockResponse',
+                (),
+                {
+                    'status_code': 200,
+                    'text': '{"uri": "test-offer-uri"}',
+                    'json': lambda self: {'uri': 'test-offer-uri'},
+                },
+            )()
             mock_post.return_value = mock_response
             _ = offer_request.call()
             mock_post.assert_called_once()
@@ -385,7 +394,9 @@ class TestOfferRequestCallMethods(SimpleTestCase):
         """Test that VeramoOfferRequest.call() handles errors correctly."""
         badge_instance = BadgeInstanceMock()
         offer_request = VeramoOfferRequest(
-            'test-credential-config-id', badge_instance, 'http://not-relevant.example.com/'  # pyright: ignore[reportArgumentType] BK: I could not manage to make a standin for a Django model that inherits or otherwise is compatible to a model
+            'test-credential-config-id',
+            badge_instance,  # pyright: ignore[reportArgumentType] BK: I could not manage to make a standin for a Django model that inherits or otherwise is compatible to a model
+            'http://not-relevant.example.com/',
         )
         offer_request.set_url('http://test-url.com')
         with patch('ob3.models.requests.post') as mock_post:
@@ -393,7 +404,7 @@ class TestOfferRequestCallMethods(SimpleTestCase):
             mock_post.return_value = mock_response
 
             with self.assertRaises(Exception) as context:
-                _= offer_request.call()
+                _ = offer_request.call()
 
             self.assertIn('Failed to create offer', str(context.exception))
             self.assertIn('400', str(context.exception))

--- a/apps/ob3/tests/tests.py
+++ b/apps/ob3/tests/tests.py
@@ -339,7 +339,7 @@ class TestOfferRequestCallMethods(SimpleTestCase):
     def test_veramo_offer_request_call_method(self):
         """Test that VeramoOfferRequest.call() works correctly."""
         badge_instance = BadgeInstanceMock()
-        callback_url = DEFAULT_DOMAIN + reverse('ob3_callback')
+        callback_url = DEFAULT_DOMAIN + reverse('ob3:callback')
         # sanity check
         expected_callback_url = 'http://0.0.0.0:8000/ob3/v1/ob3/callback'
         self.assertEqual(
@@ -352,7 +352,11 @@ class TestOfferRequestCallMethods(SimpleTestCase):
         offer_request.set_url('http://test-url.com')
 
         with patch('ob3.models.requests.post') as mock_post:
-            mock_response = type('MockResponse', (), {'status_code': 200, 'text': '{"uri": "test-offer-uri"}'})()
+            mock_response = type('MockResponse', (), {
+                'status_code': 200,
+                'text': '{"uri": "test-offer-uri"}',
+                'json': lambda self: {'uri': 'test-offer-uri'}
+            })()
             mock_post.return_value = mock_response
             _ = offer_request.call()
             mock_post.assert_called_once()

--- a/apps/ob3/tests/tests.py
+++ b/apps/ob3/tests/tests.py
@@ -1,5 +1,5 @@
 from datetime import datetime as DateTime
-from typing import List, Optional
+from typing import Any, Optional, Union
 from unittest.mock import patch
 
 from django.test import SimpleTestCase
@@ -9,16 +9,15 @@ from ob3.models import IdentityObject, ImpierceOfferRequest, VeramoOfferRequest
 from ob3.models import SphereonOfferRequest as SphereonOfferRequest
 from ob3.serializers import ImpierceOfferRequestSerializer as OfferRequestSerializer
 
-
 class BadgeClassMock:
     def __init__(self):
-        self.criteria_text = 'You must Lorem Ipsum, **dolor** _sit_ amet'
-        self.description = 'This badge is a Lorem Ipsum, **dolor** _sit_ amet'
-        self.name = 'Mock Badge'
-        self.issuer = IssuerMock()
+        self.criteria_text: str = 'You must Lorem Ipsum, **dolor** _sit_ amet'
+        self.description: str = 'This badge is a Lorem Ipsum, **dolor** _sit_ amet'
+        self.name: str = 'Mock Badge'
+        self.issuer: IssuerMock = IssuerMock()
         self.participation: Optional[str] = None
-        self.alignment_items: List[AligmentItemMock] = []
-        self.extension_items = {}
+        self.alignment_items: list[AligmentItemMock] = []
+        self.extension_items: dict[str, dict[str, Union[str, int, float]]] = {}
 
     def image_url(self):
         return 'https://example.com/images/mock.png'
@@ -26,31 +25,31 @@ class BadgeClassMock:
 
 class BadgeInstanceMock:
     def __init__(self):
-        self.entity_id = 'BADGE1234'
+        self.entity_id: str = 'BADGE1234'
         self.salt: Optional[str] = None
         self.recipient_identifier: Optional[str] = None
 
-        self.badgeclass = BadgeClassMock()
+        self.badgeclass: BadgeClassMock = BadgeClassMock()
         self.issued_on: Optional[DateTime] = None
         self.expires_at: Optional[DateTime] = None
 
 
 class IssuerMock:
     def __init__(self):
-        self.id = 'ISS1234'
-        self.name = 'Mock Issuer'
+        self.id: str = 'ISS1234'
+        self.name: str = 'Mock Issuer'
 
 
 class AligmentItemMock:
     def __init__(self):
-        self.target_name = 'interne geneeskunde'
-        self.target_url = 'https://example.com/esco/1337'
-        self.target_code = '1337'
-        self.target_framework = 'ESCO'
-        self.target_description = '# example cool'
+        self.target_name: str = 'interne geneeskunde'
+        self.target_url: str = 'https://example.com/esco/1337'
+        self.target_code: str = '1337'
+        self.target_framework: str = 'ESCO'
+        self.target_description: str = '# example cool'
 
 
-def mock_hasher(_id, _salt):
+def mock_hasher(_id: str, _salt: str):
     return 'mock_hash'
 
 
@@ -79,7 +78,7 @@ class TestCredentialsSerializers(SimpleTestCase):
             },
         }
 
-        self.maxDiff = None  # Debug full diff
+        self.maxDiff: Union[None, bool, int]  = None  # Debug full diff
         self.assertDictEqual(actual_data, expected_data)
 
     def test_recipient(self):
@@ -96,6 +95,18 @@ class TestCredentialsSerializers(SimpleTestCase):
         }
         self.assertEqual(len(actual_data['credential']['credentialSubject']['identifier']), 1)
         self.assertEqual(actual_data['credential']['credentialSubject']['identifier'][0], expected_identifier)
+
+    def test_issuer(self):
+        badge_instance = BadgeInstanceMock()
+        badge_instance.badgeclass.issuer.id = 'http://localhost:8080/ob3/issuers/ISS4567'
+        badge_instance.badgeclass.issuer.name = 'issuer name'
+        actual_data = self._serialize_it(badge_instance)
+        expected_issuer = {
+            'id': 'http://localhost:8080/ob3/issuers/ISS4567',
+            'type': ['Profile'],
+            'name': 'issuer name',
+        }
+        self.assertEqual(actual_data['credential']['issuer'], expected_issuer)
 
     def test_optional_valid_from_field_set(self):
         badge_instance = BadgeInstanceMock()
@@ -195,10 +206,10 @@ class TestCredentialsSerializers(SimpleTestCase):
 
         self.assertIn(expected_alignment, actual_data['alignment'])
 
-    def _serialize_it(self, badge_instance: BadgeInstanceMock):
+    def _serialize_it(self, badge_instance: BadgeInstanceMock) -> dict[str, Any]:  # pyright: ignore[reportExplicitAny] BK: Serialize data is too complex for our poorly typed codebase
         # TODO: We should test both impierce and sphereon models and serializers
         edu_credential = ImpierceOfferRequest('offer_id', 'credential_configuration_id', badge_instance)
-        return dict(OfferRequestSerializer(edu_credential).data)
+        return dict(OfferRequestSerializer(edu_credential).data)  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType] BK: serailzie data too complex
 
 
 class TestCredentialModels(SimpleTestCase):
@@ -312,7 +323,7 @@ class TestOfferRequestCallMethods(SimpleTestCase):
             mock_post.return_value = mock_response
 
             with self.assertRaises(Exception) as context:
-                offer_request.call()
+                _ = offer_request.call()
 
             self.assertIn('Failed to issue badge', str(context.exception))
             self.assertIn('400', str(context.exception))
@@ -330,7 +341,7 @@ class TestOfferRequestCallMethods(SimpleTestCase):
             mock_post.return_value = mock_response
 
             with self.assertRaises(Exception) as context:
-                offer_request.call()
+                _ = offer_request.call()
 
             self.assertIn('Failed to issue badge', str(context.exception))
             self.assertIn('500', str(context.exception))
@@ -374,7 +385,7 @@ class TestOfferRequestCallMethods(SimpleTestCase):
         """Test that VeramoOfferRequest.call() handles errors correctly."""
         badge_instance = BadgeInstanceMock()
         offer_request = VeramoOfferRequest(
-            'test-credential-config-id', badge_instance, 'http://not-relevant.example.com/'
+            'test-credential-config-id', badge_instance, 'http://not-relevant.example.com/'  # pyright: ignore[reportArgumentType] BK: I could not manage to make a standin for a Django model that inherits or otherwise is compatible to a model
         )
         offer_request.set_url('http://test-url.com')
         with patch('ob3.models.requests.post') as mock_post:
@@ -382,7 +393,7 @@ class TestOfferRequestCallMethods(SimpleTestCase):
             mock_post.return_value = mock_response
 
             with self.assertRaises(Exception) as context:
-                offer_request.call()
+                _= offer_request.call()
 
             self.assertIn('Failed to create offer', str(context.exception))
             self.assertIn('400', str(context.exception))

--- a/apps/ob3/tests/tests.py
+++ b/apps/ob3/tests/tests.py
@@ -35,10 +35,33 @@ class BadgeInstanceMock:
         self.expires_at: Optional[DateTime] = None
 
 
+class InstitutionMock:
+    def __init__(self):
+        self.entity_id: str = 'INST1234'
+        self.name: str = 'Mock Institution'
+
+    def image_url(self):
+        return 'https://example.com/images/institutions/mock.png'
+
+
+class FacultyMock:
+    def __init__(self):
+        self.entity_id: str = 'FAC1234'
+        self.name: str = 'Mock Faculty'
+        self.institution: InstitutionMock = InstitutionMock()
+
+    def image_url(self):
+        return 'https://example.com/images/faculties/mock.png'
+
+
 class IssuerMock:
     def __init__(self):
         self.entity_id: str = 'ISS1234'
         self.name: str = 'Mock Issuer'
+        self.faculty: FacultyMock = FacultyMock()
+
+    def image_url(self) -> str:
+        return 'https://example.com/images/issuers/mock.png'
 
 
 class AligmentItemMock:
@@ -79,6 +102,18 @@ class TestCredentialsSerializers(SimpleTestCase):
                         'description': 'This badge is a Lorem Ipsum, **dolor** _sit_ amet',
                         'name': 'Mock Badge',
                         'image': {'type': 'Image', 'id': 'https://example.com/images/mock.png'},
+                        'creator': {
+                            'type': ['Profile'],
+                            'id': f'{UI_URL}/public/faculties/FAC1234',
+                            'name': 'Mock Faculty',
+                            'image': {'type': 'Image', 'id': 'https://example.com/images/faculties/mock.png'},
+                            'parentOrg': {
+                                'type': ['Profile'],
+                                'id': f'{UI_URL}/public/institutions/INST1234',
+                                'name': 'Mock Institution',
+                                'image': {'type': 'Image', 'id': 'https://example.com/images/institutions/mock.png'},
+                            },
+                        },
                     },
                 },
             },
@@ -112,6 +147,26 @@ class TestCredentialsSerializers(SimpleTestCase):
             'image': {'type': 'Image', 'id': 'https://example.com/images/issuers/mock.png'},
         }
         self.assertEqual(actual_data['credential']['issuer'], expected_issuer)
+
+    def test_creator(self):
+        badge_instance = BadgeInstanceMock()
+        actual_data = self._serialize_it(badge_instance)
+
+        expected_data = {
+            'type': ['Profile'],
+            'id': 'http://localhost:8080/public/faculties/FAC1234',
+            'name': 'Mock Faculty',
+            'image': {'type': 'Image', 'id': 'https://example.com/images/faculties/mock.png'},
+            'parentOrg': {
+                'type': ['Profile'],
+                'id': 'http://localhost:8080/public/institutions/INST1234',
+                'name': 'Mock Institution',
+                'image': {'type': 'Image', 'id': 'https://example.com/images/institutions/mock.png'},
+            },
+        }
+
+        self.maxDiff: Union[int, None] = None
+        self.assertEqual(actual_data['credential']['credentialSubject']['achievement']['creator'], expected_data)
 
     def test_optional_valid_from_field_set(self):
         badge_instance = BadgeInstanceMock()


### PR DESCRIPTION
@ThomasKalverda: Ik vermoed dat je niet helemaal zult begrijpen wat hier gebeurt, maar juist daarom heb ik jou als reviewer aangemerkt :)

Kun je zien wat die serializers zoal doen in de ewi-branch. 

## Waarom deze change?

We voegen wat velden toe aan de serializers.

Van https://git.ia.surfsara.nl/surf-internal/educational-logistics/edubadges/edubadges/-/work_items/67

> Zodat we "issuers" (die uit badgr), "faculties" en "institutions" kunenn opnemen in badges, nemen we deze in "creator" veld op
> 
>  ```
>    De info van de "issuer":
>     name, url(optional), image
> 	parentOrg: faculty
> 	van faculty:
> 	  name:, url image
> 	  parentOrg: institution
> 	  van institution:
> 	  name, url, image
> ```
> 
> Dit staat dan los van het "issuer" veld uit dezelfde badge. Dat issuer veld beschrijft de daadwerkelijke issuer(agent) en dat is "Edubadges"
> Wanneer we deze in de serializer van de OpenBadgeCredentials hebben gebouwd, en deze dus in de badges die in wallets terechtkomen, zit, kunnen we dit bij EWI presenteren:
> Probleem: "issuer" van alle openbadges in de pilot is "EduBadges" en niet bijv "UvA" of "TU Delft". Visuele en zichtbare identiteit van de maker van de badge, via de hierarchie in de creator, kan door walletbouwers gebruikt worden om weer te geven wie een badge heeft gemaakt - en minder nadruk op de "issuer" te leggen, hierbij.

In tegenstelling tot in dat ticket, heb ik de `creator` nu juist de Faculty gemaakt. De hele excercitie heeft weinig zin als "issuer" en "creator" bijna hetzelfde zijn :).

Ik ga er vanuit dat:
- Alle issuers een faculty hebben
- Alle faculties een institution hebben
- issuers, faculties, en instiutions altijd een image hebben

Zover ik kan nagaan in de data-models hoort dat ook zo te zijn - behoorlijk wat methods en andere code gaat ook van deze strucuur uit en ze wordt een beetje afgedwongen in de CR (van CRUD) layer - niet echt in het datamodel en al helemaal niet in de database (met bijv foreign key constraints) zover ik kan zien. Het is dus technisch mogelijk, denk ik, dat deze aannames niet kloppen en zo'n serializer zal klappen. 

Uiteraard had ik allerhande failsafes en fallbacks kunnen inbouwen, maar omdat we dat elders ook al niet doen, leek me dat onzinnig: Dan kan een obscure, nauwelijks gebruike feature, beter met "kapotte" data omgaan dan veel van de rest van de app :).

## Hoe?

Algemeen over de serializer-opzet:

OB3 serialized django models in een structuur die https://www.imsglobal.org/spec/ob/v3p0/#achievementcredential volgt.

Wat ik doe, is dat ik eerst `POPO`s maak van de (veel te complexe en veel te grote) Records. Dat zijn de 'models'. 
Die piepel ik dan door de Serializers heen.

Idealiter, is het idee: FooRecord -> FooModel -> FooSerializer -> json
Waarbij in de `FooModel` de businesslogic zit om bijv attributen erin op te nemen etc. En waarbij de `Serializer` al die data omzet naar de structuren van OBV3.

Waarom? 
Ik werd helemaal kriegel van hoe Django, REST etc het serializen koppelt aan je datamodel. Vooral omdat we dat hier juist niet willen. Daarom heb ik die *model* laag ertussen gelegd. 

Zoals je kunt zien, begrijp ik de serializers ook nog maar half. Bijv de ImageSerializer die alles van "image_url" naar `{ "id": image_url }` zou moeten piepelen *in de serializer*: maar dat lukte me niet, dus zit het in de models (die ik wel snap).

Verder heb ik wat "magic" toegevoegd met van die mixins, niet mijn favo, maar schijnbaar gebrukelijk in Python: IIG ken ik dit soort 😨-code nog goed uit mijn Ruby tijd. Ik ben met deze hele serializer opzet begonnen toen ik *nog* minder van Python kende -- dat is vast te zien ....

