### PR TITLE
Only show terms with institution in mobile terms endpoint

### DIFF
--- a/apps/mobile_api/api.py
+++ b/apps/mobile_api/api.py
@@ -1377,7 +1377,7 @@ class TermsAgreementViewSet(viewsets.ModelViewSet):
     lookup_field = 'entity_id'
 
     def get_queryset(self):
-        return TermsAgreement.objects.filter(user=self.request.user)
+        return TermsAgreement.objects.filter(user=self.request.user, terms__institution__isnull=False)
 
     def get_serializer_class(self):
         if self.action == 'create':


### PR DESCRIPTION
In our current web backpack, we filter in the frontend on terms that have an institution, so I added that filter to the queryset for the mobile endpoint for terms as well.

In the profile and login mobile endpoints, the general terms are still returned.