### PR TITLE
EB-17: prevent memcached pymemcache FD leak from crashing badge serialization

### DIFF
--- a/apps/cachemodel/decorators.py
+++ b/apps/cachemodel/decorators.py
@@ -10,10 +10,17 @@ def cached_method(auto_publish=False):
         @wraps(target)
         def wrapper(self, *args, **kwargs):
             key = generate_cache_key([self.__class__.__name__, target.__name__, self.pk], *args, **kwargs)
-            data = cache.get(key)
+            try:
+                data = cache.get(key)
+            except (OSError, ConnectionError, TimeoutError):
+                # pymemcache leaks FDs on connection errors; fall back to uncached
+                data = None
             if data is None:
                 data = target(self, *args, **kwargs)
-                cache.set(key, data, CACHE_FOREVER_TIMEOUT)
+                try:
+                    cache.set(key, data, CACHE_FOREVER_TIMEOUT)
+                except (OSError, ConnectionError, TimeoutError):
+                    pass  # cache.set failure is non-fatal
             return data
         wrapper._cached_method = True
         wrapper._cached_method_auto_publish = auto_publish

--- a/apps/mainsite/settings.py
+++ b/apps/mainsite/settings.py
@@ -391,6 +391,10 @@ CACHES = {
         # using django_prometheus to monitor cache: https://github.com/korfuri/django-prometheus/blob/master/README.md#monitoring-your-caches
         "BACKEND": "django_prometheus.cache.backends.memcached.PyMemcacheCache",
         "LOCATION": os.environ.get("MEMCACHED", "0.0.0.0:11211"),
+        "OPTIONS": {
+            "pool_size": 10,       # max concurrent connections per server
+            "timeout": 5,          # socket timeout (seconds) — prevents slow FD leaks
+        },
     }
 }
 


### PR DESCRIPTION
Wrap cache.get/cache.set in try/except in cached_method decorator so pymemcache connection errors (OSError/ConnectionError/TimeoutError) degrade gracefully instead of raising 500.

Add pool_size and timeout to cache OPTIONS to bound connection creation and prevent hung connections from holding file descriptors open.

Root cause: a list endpoint calls user_may_enroll() per badge, each of which calls user.schac_homes -> cached_affiliations() -> cache.get(). When memcached is unreachable or slow, pymemcache leaks one FD per connection attempt until ulimit is hit.