### PR TITLE
EB-17: slim mobile catalog and move user-specific fields to detail view to improve perf

### DIFF
--- a/apps/mobile_api/api.py
+++ b/apps/mobile_api/api.py
@@ -8,7 +8,7 @@ from fcm_django.api.rest_framework import FCMDeviceAuthorizedViewSet, FCMDeviceS
 
 from badgeuser.models import StudentAffiliation, TermsAgreement
 from directaward.models import DirectAward, DirectAwardBundle
-from django.db.models import Q, Subquery
+from django.db.models import Subquery
 from django.shortcuts import get_object_or_404
 from drf_spectacular.utils import (
     OpenApiExample,
@@ -1093,47 +1093,6 @@ class CatalogBadgeClassListView(generics.ListAPIView):
             200: OpenApiResponse(
                 description='Paginated list of badge classes',
                 response=CatalogBadgeClassSerializer(many=True),
-                examples=[
-                    OpenApiExample(
-                        'Filtered and Paginated Badge Classes Example',
-                        value={
-                            'count': 124,
-                            'next': 'https://api.example.com/catalog/badge-classes/?page=2&page_size=2&q=edubadge',
-                            'previous': None,
-                            'results': [
-                                {
-                                    'created_at': '2025-05-02T12:20:51.573423',
-                                    'name': 'Edubadge account complete',
-                                    'image': 'uploads/badges/edubadge_student.png',
-                                    'archived': 0,
-                                    'entity_id': 'qNGehQ2dRTKyjNtiDvhWsQ',
-                                    'is_private': 0,
-                                    'is_micro_credentials': 0,
-                                    'badge_class_type': 'regular',
-                                    'issuer_name_english': 'Team edubadges',
-                                    'issuer_name_dutch': 'Team edubadges',
-                                    'issuer_entity_id': 'WOLxSjpWQouas1123Z809Q',
-                                    'issuer_image_dutch': '',
-                                    'issuer_image_english': 'uploads/issuers/surf.png',
-                                    'faculty_name_english': 'eduBadges',
-                                    'faculty_name_dutch': 'null',
-                                    'faculty_entity_id': 'lVu1kbaqSDyJV_1Bu8_bcw',
-                                    'faculty_image_dutch': '',
-                                    'faculty_image_english': '',
-                                    'faculty_on_behalf_of': 0,
-                                    'faculty_type': 'null',
-                                    'institution_name_english': 'SURF',
-                                    'institution_name_dutch': 'SURF',
-                                    'institution_entity_id': 'NiqkZiz2TaGT8B4RRwG8Fg',
-                                    'institution_image_dutch': 'uploads/issuers/surf.png',
-                                    'institution_image_english': 'uploads/issuers/surf.png',
-                                    'institution_type': 'null',
-                                },
-                            ],
-                        },
-                        response_only=True,
-                    )
-                ],
             ),
             500: OpenApiResponse(description='Internal server error occurred while retrieving badge classes.'),
         },

--- a/apps/mobile_api/api.py
+++ b/apps/mobile_api/api.py
@@ -8,7 +8,7 @@ from fcm_django.api.rest_framework import FCMDeviceAuthorizedViewSet, FCMDeviceS
 
 from badgeuser.models import StudentAffiliation, TermsAgreement
 from directaward.models import DirectAward, DirectAwardBundle
-from django.db.models import Q, Subquery, Count
+from django.db.models import Q, Subquery
 from django.shortcuts import get_object_or_404
 from drf_spectacular.utils import (
     OpenApiExample,
@@ -1110,35 +1110,6 @@ class CatalogBadgeClassListView(generics.ListAPIView):
                                     'is_private': 0,
                                     'is_micro_credentials': 0,
                                     'badge_class_type': 'regular',
-                                    'required_terms': {
-                                        'entity_id': 'terms-123',
-                                        'terms_type': 'FORMAL_BADGE',
-                                        'institution': {
-                                            'name_dutch': 'SURF',
-                                            'name_english': 'SURF',
-                                            'image_dutch': '',
-                                            'image_english': '',
-                                            'identifier': 'surf.nl',
-                                            'alternative_identifier': None,
-                                            'grondslag_formeel': 'gerechtvaardigd_belang',
-                                            'grondslag_informeel': 'gerechtvaardigd_belang'
-                                        },
-                                        'terms_urls': [
-                                            {
-                                                'url': 'https://example.org/terms/nl',
-                                                'language': 'nl',
-                                                'excerpt': 'Door deel te nemen accepteer je...'
-                                            },
-                                            {
-                                                'url': 'https://example.org/terms/en',
-                                                'language': 'en',
-                                                'excerpt': 'By participating you accept...'
-                                            }
-                                        ]
-                                    },
-                                    'user_has_accepted_terms': True,
-                                    'self_enrollment_enabled': True,
-                                    'user_may_enroll': True,
                                     'issuer_name_english': 'Team edubadges',
                                     'issuer_name_dutch': 'Team edubadges',
                                     'issuer_entity_id': 'WOLxSjpWQouas1123Z809Q',
@@ -1157,67 +1128,6 @@ class CatalogBadgeClassListView(generics.ListAPIView):
                                     'institution_image_dutch': 'uploads/issuers/surf.png',
                                     'institution_image_english': 'uploads/issuers/surf.png',
                                     'institution_type': 'null',
-                                    'self_requested_assertions_count': 1,
-                                    'direct_awarded_assertions_count': 0,
-                                },
-                                {
-                                    'created_at': '2025-05-02T12:20:57.914064',
-                                    'name': 'Growth and Development',
-                                    'image': 'uploads/badges/eduid.png',
-                                    'archived': 0,
-                                    'entity_id': 'Ge4D7gf1RLGYNZlSiCv-qA',
-                                    'is_private': 0,
-                                    'is_micro_credentials': 0,
-                                    'badge_class_type': 'regular',
-                                    'required_terms': {
-                                        'entity_id': 'terms-123',
-                                        'terms_type': 'FORMAL_BADGE',
-                                        'institution': {
-                                            'name_dutch': 'SURF',
-                                            'name_english': 'SURF',
-                                            'image_dutch': '',
-                                            'image_english': '',
-                                            'identifier': 'surf.nl',
-                                            'alternative_identifier': None,
-                                            'grondslag_formeel': 'gerechtvaardigd_belang',
-                                            'grondslag_informeel': 'gerechtvaardigd_belang'
-                                        },
-                                        'terms_urls': [
-                                            {
-                                                'url': 'https://example.org/terms/nl',
-                                                'language': 'nl',
-                                                'excerpt': 'Door deel te nemen accepteer je...'
-                                            },
-                                            {
-                                                'url': 'https://example.org/terms/en',
-                                                'language': 'en',
-                                                'excerpt': 'By participating you accept...'
-                                            }
-                                        ]
-                                    },
-                                    'user_has_accepted_terms': True,
-                                    'self_enrollment_enabled': True,
-                                    'user_may_enroll': True,
-                                    'issuer_name_english': 'Medicine',
-                                    'issuer_name_dutch': 'null',
-                                    'issuer_entity_id': 'yuflXDK8ROukQkxSPmh5ag',
-                                    'issuer_image_dutch': '',
-                                    'issuer_image_english': 'uploads/issuers/surf.png',
-                                    'faculty_name_english': 'Medicine',
-                                    'faculty_name_dutch': 'null',
-                                    'faculty_entity_id': 'yYPphJ3bS5qszI7P69degA',
-                                    'faculty_image_dutch': '',
-                                    'faculty_image_english': '',
-                                    'faculty_on_behalf_of': 0,
-                                    'faculty_type': 'null',
-                                    'institution_name_english': 'university-example.org',
-                                    'institution_name_dutch': 'null',
-                                    'institution_entity_id': '5rZhvRonT3OyyLQhhmuPmw',
-                                    'institution_image_dutch': 'uploads/institution/surf.png',
-                                    'institution_image_english': 'uploads/institution/surf.png',
-                                    'institution_type': 'WO',
-                                    'self_requested_assertions_count': 0,
-                                    'direct_awarded_assertions_count': 0,
                                 },
                             ],
                         },
@@ -1235,26 +1145,13 @@ class CatalogBadgeClassListView(generics.ListAPIView):
                 'issuer__faculty',
                 'issuer__faculty__institution',
             )
-            .prefetch_related(
-                'issuer__faculty__institution__terms',
-                'issuer__faculty__institution__terms__terms_urls',
-            )
             .filter(
                 is_private=False,
                 issuer__archived=False,
                 issuer__faculty__archived=False,
             )
             .exclude(issuer__faculty__visibility_type='TEST')
-            .annotate(
-                selfRequestedAssertionsCount=Count(
-                    'badgeinstances',
-                    filter=Q(badgeinstances__award_type='requested'),
-                ),
-                directAwardedAssertionsCount=Count(
-                    'badgeinstances',
-                    filter=Q(badgeinstances__award_type='direct_award'),
-                ),
-            ).order_by('name')
+            .order_by('name')
         )
 
 
@@ -1296,6 +1193,8 @@ class BadgeClassDetailView(generics.RetrieveAPIView):
     ).prefetch_related(
         'badgeclassextension_set',
         'badgeclassalignment_set',
+        'issuer__faculty__institution__terms',
+        'issuer__faculty__institution__terms__terms_urls',
     )
 
 

--- a/apps/mobile_api/api.py
+++ b/apps/mobile_api/api.py
@@ -16,7 +16,8 @@ from drf_spectacular.utils import (
     OpenApiResponse,
     OpenApiTypes,
     extend_schema,
-    inline_serializer, extend_schema_view,
+    inline_serializer,
+    extend_schema_view,
 )
 
 from institution.models import Institution
@@ -51,9 +52,9 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 permission_denied_response = OpenApiResponse(
-    response=inline_serializer(name='PermissionDeniedResponse', fields={'detail': serializers.CharField()}),
+    response=inline_serializer(name="PermissionDeniedResponse", fields={"detail": serializers.CharField()}),
     examples=[
-        OpenApiExample(name='Forbidden Response', value={'detail': 'Authentication credentials were not provided.'})
+        OpenApiExample(name="Forbidden Response", value={"detail": "Authentication credentials were not provided."})
     ],
 )
 
@@ -62,119 +63,110 @@ class Login(APIView):
     permission_classes = (MobileAPIPermission,)
 
     @extend_schema(
-        methods=['GET'],
-        description='Retrieve current user and sync eduID data',
+        methods=["GET"],
+        description="Retrieve current user and sync eduID data",
         responses={
             200: OpenApiResponse(
                 response=UserSerializer,
-                description='Current user data, synchronized with eduID. The presence of `validated_name` indicates whether the user has connected his eduID account to an other service like a bank or institution.',
+                description="Current user data, synchronized with eduID. The presence of `validated_name` indicates whether the user has connected his eduID account to an other service like a bank or institution.",
                 examples=[
                     OpenApiExample(
-                        name='User with validated name',
+                        name="User with validated name",
                         value={
-                            'email': 'jdoe@example.com',
-                            'last_name': 'Doe',
-                            'first_name': 'John',
-                            'validated_name': 'John Doe',
-                            'schac_homes': ['university-example.org'],
-                            'terms_agreed': True,
-                            'termsagreement_set': [
+                            "email": "jdoe@example.com",
+                            "last_name": "Doe",
+                            "first_name": "John",
+                            "validated_name": "John Doe",
+                            "schac_homes": ["university-example.org"],
+                            "terms_agreed": True,
+                            "termsagreement_set": [
                                 {
-                                    'agreed': True,
-                                    'agreed_version': 1,
-                                    'terms': {
-                                        'terms_type': 'service_agreement_student'
-                                    },
+                                    "agreed": True,
+                                    "agreed_version": 1,
+                                    "terms": {"terms_type": "service_agreement_student"},
                                 },
                                 {
-                                    'agreed': True,
-                                    'agreed_version': 1,
-                                    'terms': {
-                                        'terms_type': 'terms_of_service',
-                                        'institution': None
-                                    },
+                                    "agreed": True,
+                                    "agreed_version": 1,
+                                    "terms": {"terms_type": "terms_of_service", "institution": None},
                                 },
                             ],
                         },
-                        description='User has a validated name in eduID.',
+                        description="User has a validated name in eduID.",
                         response_only=True,
                     ),
                     OpenApiExample(
-                        name='User without validated name',
+                        name="User without validated name",
                         value={
-                            'email': 'jdoe@example.com',
-                            'last_name': 'Doe',
-                            'first_name': 'John',
-                            'validated_name': None,
-                            'schac_homes': [],
-                            'terms_agreed': False,
-                            'termsagreement_set': [],
+                            "email": "jdoe@example.com",
+                            "last_name": "Doe",
+                            "first_name": "John",
+                            "validated_name": None,
+                            "schac_homes": [],
+                            "terms_agreed": False,
+                            "termsagreement_set": [],
                         },
-                        description='User does not have a validated name (yet).',
+                        description="User does not have a validated name (yet).",
                         response_only=True,
                     ),
                     OpenApiExample(
-                        name='User without agreed terms',
+                        name="User without agreed terms",
                         value={
-                            'email': 'jdoe@example.com',
-                            'last_name': 'Doe',
-                            'first_name': 'John',
-                            'validated_name': 'John Doe',
-                            'schac_homes': ['university-example.org'],
-                            'terms_agreed': False,
-                            'termsagreement_set': [],
+                            "email": "jdoe@example.com",
+                            "last_name": "Doe",
+                            "first_name": "John",
+                            "validated_name": "John Doe",
+                            "schac_homes": ["university-example.org"],
+                            "terms_agreed": False,
+                            "termsagreement_set": [],
                         },
-                        description='User did not accept terms (yet).',
+                        description="User did not accept terms (yet).",
                         response_only=True,
                     ),
                 ],
             ),
-
             # 🔐 Auth / permission errors
             401: OpenApiResponse(
-                description='Authentication failed (missing or invalid bearer token)',
+                description="Authentication failed (missing or invalid bearer token)",
                 examples=[
                     OpenApiExample(
-                        name='Missing token',
-                        value={'detail': 'Authentication credentials were not provided.'},
+                        name="Missing token",
+                        value={"detail": "Authentication credentials were not provided."},
                     ),
                     OpenApiExample(
-                        name='Invalid token',
-                        value={'detail': 'Invalid or expired token.'},
+                        name="Invalid token",
+                        value={"detail": "Invalid or expired token."},
                     ),
                 ],
             ),
-
             403: permission_denied_response,
-
             # 🌐 External dependency errors
             502: OpenApiResponse(
-                description='eduID service error or unavailable',
+                description="eduID service error or unavailable",
                 examples=[
                     OpenApiExample(
-                        name='eduID unavailable',
-                        value={'error': 'eduID unavailable'},
+                        name="eduID unavailable",
+                        value={"error": "eduID unavailable"},
                     ),
                     OpenApiExample(
-                        name='eduID error',
-                        value={'error': 'eduID error'},
+                        name="eduID error",
+                        value={"error": "eduID error"},
                     ),
                 ],
             ),
-
             504: OpenApiResponse(
-                description='eduID request timeout',
+                description="eduID request timeout",
                 examples=[
                     OpenApiExample(
-                        name='Timeout',
-                        value={'error': 'eduID timeout'},
+                        name="Timeout",
+                        value={"error": "eduID timeout"},
                     ),
                 ],
             ),
         },
     )
     def get(self, request, **kwargs):
-        logger = logging.getLogger('Badgr.Debug')
+        logger = logging.getLogger("Badgr.Debug")
 
         user = request.user
 
@@ -191,16 +183,16 @@ class Login(APIView):
             eduid_data = client.get_links()
 
         except requests.Timeout:
-            logger.warning('eduID timeout')
-            return Response({'error': 'eduID timeout'}, status=504)
+            logger.warning("eduID timeout")
+            return Response({"error": "eduID timeout"}, status=504)
 
         except requests.HTTPError as e:
-            logger.exception('eduID returned error')
-            return Response({'error': 'eduID error'}, status=502)
+            logger.exception("eduID returned error")
+            return Response({"error": "eduID error"}, status=502)
 
         except requests.RequestException:
-            logger.exception('eduID unavailable')
-            return Response({'error': 'eduID unavailable'}, status=502)
+            logger.exception("eduID unavailable")
+            return Response({"error": "eduID unavailable"}, status=502)
 
         # Sync user state
         sync_user_with_eduid(user, eduid_data, logger)
@@ -214,19 +206,19 @@ class AcceptGeneralTerms(APIView):
     permission_classes = (MobileAPIPermission,)
 
     @extend_schema(
-        methods=['GET'],
-        description='Accept the general terms',
+        methods=["GET"],
+        description="Accept the general terms",
         responses={
             200: OpenApiResponse(
-                description='Terms accepted successfully',
+                description="Terms accepted successfully",
                 response=inline_serializer(
-                    name='AcceptGeneralTermsResponse', fields={'status': serializers.CharField()}
+                    name="AcceptGeneralTermsResponse", fields={"status": serializers.CharField()}
                 ),
                 examples=[
                     OpenApiExample(
-                        'Terms Accepted',
-                        value={'status': 'ok'},
-                        description='User has successfully accepted the general terms',
+                        "Terms Accepted",
+                        value={"status": "ok"},
+                        description="User has successfully accepted the general terms",
                         response_only=True,
                     ),
                 ],
@@ -235,73 +227,73 @@ class AcceptGeneralTerms(APIView):
         },
     )
     def get(self, request, **kwargs):
-        logger = logging.getLogger('Badgr.Debug')
+        logger = logging.getLogger("Badgr.Debug")
         user = request.user
         user.accept_general_terms()
         user.save()
-        logger.info(f'Accepted general terms for user {user.email}')
-        return Response(data={'status': 'ok'})
+        logger.info(f"Accepted general terms for user {user.email}")
+        return Response(data={"status": "ok"})
 
 
 class BadgeInstances(APIView):
     permission_classes = (MobileAPIPermission,)
 
     @extend_schema(
-        methods=['GET'],
-        description='Get all assertions for the user',
+        methods=["GET"],
+        description="Get all assertions for the user",
         responses={
             200: OpenApiResponse(
-                description='List of badge instances',
+                description="List of badge instances",
                 response=BadgeInstanceSerializer(many=True),
                 examples=[
                     OpenApiExample(
-                        'Badge Instances List',
+                        "Badge Instances List",
                         value=[
                             {
-                                'id': 2,
-                                'created_at': '2021-04-20T16:20:30.528668+02:00',
-                                'entity_id': 'I41eovHQReGI_SG5KM6dSQ',
-                                'issued_on': '2021-04-20T16:20:30.521307+02:00',
-                                'award_type': 'requested',
-                                'revoked': 'false',
-                                'expires_at': '2030-04-20T16:20:30.521307+02:00',
-                                'acceptance': 'Accepted',
-                                'public': 'true',
-                                'badgeclass': {
-                                    'id': 3,
-                                    'name': 'Edubadge account complete',
-                                    'entity_id': 'nwsL-dHyQpmvOOKBscsN_A',
-                                    'image_url': 'https://api-demo.edubadges.nl/media/uploads/badges/issuer_badgeclass_548517aa-cbab-4a7b-a971-55cdcce0e2a5.png',
-                                    'issuer': {
-                                        'name_dutch': 'SURF Edubadges',
-                                        'name_english': 'SURF Edubadges',
-                                        'image_dutch': 'null',
-                                        'image_english': '/media/uploads/issuers/issuer_logo_ccd075bb-23cb-40b2-8780-b5a7eda9de1c.png',
-                                        'faculty': {
-                                            'name_dutch': 'SURF',
-                                            'name_english': 'SURF',
-                                            'image_dutch': 'null',
-                                            'image_english': 'null',
-                                            'on_behalf_of': 'false',
-                                            'on_behalf_of_display_name': 'null',
-                                            'on_behalf_of_url': 'null',
-                                            'institution': {
-                                                'name_dutch': 'University Voorbeeld',
-                                                'name_english': 'University Example',
-                                                'image_dutch': '/media/uploads/institution/d0273589-2c7a-4834-8c35-fef4695f176a.png',
-                                                'image_english': '/media/uploads/institution/eae5465f-98b1-4849-ac2d-47d4e1cd1252.png',
-                                                'identifier': 'university-example.org',
-                                                'alternative_identifier': 'university-example.org.tempguestidp.edubadges.nl',
-                                                'grondslag_formeel': 'gerechtvaardigd_belang',
-                                                'grondslag_informeel': 'gerechtvaardigd_belang',
+                                "id": 2,
+                                "created_at": "2021-04-20T16:20:30.528668+02:00",
+                                "entity_id": "I41eovHQReGI_SG5KM6dSQ",
+                                "issued_on": "2021-04-20T16:20:30.521307+02:00",
+                                "award_type": "requested",
+                                "revoked": "false",
+                                "expires_at": "2030-04-20T16:20:30.521307+02:00",
+                                "acceptance": "Accepted",
+                                "public": "true",
+                                "badgeclass": {
+                                    "id": 3,
+                                    "name": "Edubadge account complete",
+                                    "entity_id": "nwsL-dHyQpmvOOKBscsN_A",
+                                    "image_url": "https://api-demo.edubadges.nl/media/uploads/badges/issuer_badgeclass_548517aa-cbab-4a7b-a971-55cdcce0e2a5.png",
+                                    "issuer": {
+                                        "name_dutch": "SURF Edubadges",
+                                        "name_english": "SURF Edubadges",
+                                        "image_dutch": "null",
+                                        "image_english": "/media/uploads/issuers/issuer_logo_ccd075bb-23cb-40b2-8780-b5a7eda9de1c.png",
+                                        "faculty": {
+                                            "name_dutch": "SURF",
+                                            "name_english": "SURF",
+                                            "image_dutch": "null",
+                                            "image_english": "null",
+                                            "on_behalf_of": "false",
+                                            "on_behalf_of_display_name": "null",
+                                            "on_behalf_of_url": "null",
+                                            "institution": {
+                                                "name_dutch": "University Voorbeeld",
+                                                "name_english": "University Example",
+                                                "image_dutch": "/media/uploads/institution/d0273589-2c7a-4834-8c35-fef4695f176a.png",
+                                                "image_english": "/media/uploads/institution/eae5465f-98b1-4849-ac2d-47d4e1cd1252.png",
+                                                "identifier": "university-example.org",
+                                                "alternative_identifier": "university-example.org.tempguestidp.edubadges.nl",
+                                                "grondslag_formeel": "gerechtvaardigd_belang",
+                                                "grondslag_informeel": "gerechtvaardigd_belang",
                                             },
                                         },
                                     },
                                 },
-                                'grade_achieved': '33',
+                                "grade_achieved": "33",
                             },
                         ],
-                        description='Array of badge instances belonging to the user',
+                        description="Array of badge instances belonging to the user",
                         response_only=True,
                     ),
                 ],
@@ -314,15 +306,15 @@ class BadgeInstances(APIView):
         # ManyToManyField / reverse FK → prefetch_related
 
         instances = (
-            BadgeInstance.objects.select_related('badgeclass')
-            .select_related('badgeclass__issuer')
-            .select_related('badgeclass__issuer__faculty')
-            .select_related('badgeclass__issuer__faculty__institution')
+            BadgeInstance.objects.select_related("badgeclass")
+            .select_related("badgeclass__issuer")
+            .select_related("badgeclass__issuer__faculty")
+            .select_related("badgeclass__issuer__faculty__institution")
             .filter(
                 user=request.user,
                 revoked=False,
             )
-            .order_by('-issued_on')
+            .order_by("-issued_on")
         )
         serializer = BadgeInstanceSerializer(instances, many=True)
         return Response(serializer.data)
@@ -332,135 +324,135 @@ class BadgeInstanceDetail(APIView):
     permission_classes = (MobileAPIPermission,)
 
     @extend_schema(
-        methods=['GET'],
-        description='Get details for a badge instance',
+        methods=["GET"],
+        description="Get details for a badge instance",
         parameters=[
             OpenApiParameter(
-                name='entity_id',
+                name="entity_id",
                 type=OpenApiTypes.STR,
                 location=OpenApiParameter.PATH,
                 required=True,
-                description='entity_id of the badge instance',
+                description="entity_id of the badge instance",
             )
         ],
         responses={
             200: OpenApiResponse(
-                description='Badge instance details',
+                description="Badge instance details",
                 response=BadgeInstanceDetailSerializer,
                 examples=[
                     OpenApiExample(
-                        'Badge Instance Details',
+                        "Badge Instance Details",
                         value={
-                            'id': 2,
-                            'created_at': '2021-04-20T16:20:30.528668+02:00',
-                            'entity_id': 'I41eovHQReGI_SG5KM6dSQ',
-                            'issued_on': '2021-04-20T16:20:30.521307+02:00',
-                            'award_type': 'requested',
-                            'revoked': 'false',
-                            'expires_at': 'null',
-                            'acceptance': 'Accepted',
-                            'public': 'true',
-                            'linkedin_url': 'https://www.linkedin.com/profile/add?startTask=CERTIFICATION_NAME&name=Edubadge%20account%20complete&organizationId=206815&issueYear=2021&issueMonth=3&certUrl=https%3A%2F%2Fdemo.edubadges.nl%2Fpublic%2Fassertions%2FI41eovHQReGI_SG5KM6dSQ&certId=I41eovHQReGI_SG5KM6dSQ&original_referer=https%3A%2F%2Fdemo.edubadges.nl',
-                            'include_grade_achieved': 'true',
-                            'grade_achieved': '8',
-                            'include_evidence': 'true',
-                            'evidences': [
+                            "id": 2,
+                            "created_at": "2021-04-20T16:20:30.528668+02:00",
+                            "entity_id": "I41eovHQReGI_SG5KM6dSQ",
+                            "issued_on": "2021-04-20T16:20:30.521307+02:00",
+                            "award_type": "requested",
+                            "revoked": "false",
+                            "expires_at": "null",
+                            "acceptance": "Accepted",
+                            "public": "true",
+                            "linkedin_url": "https://www.linkedin.com/profile/add?startTask=CERTIFICATION_NAME&name=Edubadge%20account%20complete&organizationId=206815&issueYear=2021&issueMonth=3&certUrl=https%3A%2F%2Fdemo.edubadges.nl%2Fpublic%2Fassertions%2FI41eovHQReGI_SG5KM6dSQ&certId=I41eovHQReGI_SG5KM6dSQ&original_referer=https%3A%2F%2Fdemo.edubadges.nl",
+                            "include_grade_achieved": "true",
+                            "grade_achieved": "8",
+                            "include_evidence": "true",
+                            "evidences": [
                                 {
-                                    'evidence_url': 'https://example.com',
-                                    'narrative': 'Personal message from the awarder to the receiver',
-                                    'name': 'evidence name',
-                                    'description': 'evidence description',
+                                    "evidence_url": "https://example.com",
+                                    "narrative": "Personal message from the awarder to the receiver",
+                                    "name": "evidence name",
+                                    "description": "evidence description",
                                 },
                                 {
-                                    'evidence_url': 'https://example.com',
-                                    'narrative': 'Personal message from the awarder to the receiver',
-                                    'name': 'evidence name',
-                                    'description': 'evidence description',
+                                    "evidence_url": "https://example.com",
+                                    "narrative": "Personal message from the awarder to the receiver",
+                                    "name": "evidence name",
+                                    "description": "evidence description",
                                 },
                             ],
-                            'badgeclass': {
-                                'id': 3,
-                                'name': 'Edubadge account complete',
-                                'entity_id': 'nwsL-dHyQpmvOOKBscsN_A',
-                                'image': '/media/uploads/badges/issuer_badgeclass_548517aa-cbab-4a7b-a971-55cdcce0e2a5.png',
-                                'description': '### Welcome to edubadges. Let your life long learning begin! ###\r\n\r\nYou are now ready to collect all your edubadges in your backpack. In your backpack you can store and manage them safely.\r\n\r\nShare them anytime you like and with whom you like.\r\n\r\nEdubadges are visual representations of your knowledge, skills and competences.',
-                                'formal': 'false',
-                                'badge_class_type': 'regular',
-                                'expiration_period': 'null',
-                                'participation': 'blended',
-                                'assessment_type': 'written_exam',
-                                'assessment_id_verified': 'false',
-                                'assessment_supervised': 'false',
-                                'quality_assurance_name': 'FAKE1.0',
-                                'quality_assurance_url': 'https://example.com/qaf/FAKE1.0',
-                                'quality_assurance_description': 'Quality assurance framework FAKE1.0',
-                                'stackable': 'false',
-                                'self_enrollment_enabled': 'true',
-                                'user_may_enroll': 'false',
-                                'criteria_text': 'In order to earn this badge, you must complete the course and show proficiency in things.',
-                                'eqf_nlqf_level_verified': 'false',
-                                'alignments': [
+                            "badgeclass": {
+                                "id": 3,
+                                "name": "Edubadge account complete",
+                                "entity_id": "nwsL-dHyQpmvOOKBscsN_A",
+                                "image": "/media/uploads/badges/issuer_badgeclass_548517aa-cbab-4a7b-a971-55cdcce0e2a5.png",
+                                "description": "### Welcome to edubadges. Let your life long learning begin! ###\r\n\r\nYou are now ready to collect all your edubadges in your backpack. In your backpack you can store and manage them safely.\r\n\r\nShare them anytime you like and with whom you like.\r\n\r\nEdubadges are visual representations of your knowledge, skills and competences.",
+                                "formal": "false",
+                                "badge_class_type": "regular",
+                                "expiration_period": "null",
+                                "participation": "blended",
+                                "assessment_type": "written_exam",
+                                "assessment_id_verified": "false",
+                                "assessment_supervised": "false",
+                                "quality_assurance_name": "FAKE1.0",
+                                "quality_assurance_url": "https://example.com/qaf/FAKE1.0",
+                                "quality_assurance_description": "Quality assurance framework FAKE1.0",
+                                "stackable": "false",
+                                "self_enrollment_enabled": "true",
+                                "user_may_enroll": "false",
+                                "criteria_text": "In order to earn this badge, you must complete the course and show proficiency in things.",
+                                "eqf_nlqf_level_verified": "false",
+                                "alignments": [
                                     {
-                                        'target_name': 'EQF',
-                                        'target_url': 'https://ec.europa.eu/ploteus/content/descriptors-page',
-                                        'target_description': 'European Qualifications Framework',
-                                        'target_framework': 'EQF',
-                                        'target_code': '7',
+                                        "target_name": "EQF",
+                                        "target_url": "https://ec.europa.eu/ploteus/content/descriptors-page",
+                                        "target_description": "European Qualifications Framework",
+                                        "target_framework": "EQF",
+                                        "target_code": "7",
                                     },
                                     {
-                                        'target_name': 'ECTS',
-                                        'target_url': 'https://ec.europa.eu/education/resources-and-tools/european-credit-transfer-and-accumulation-system-ects_en',
-                                        'target_description': 'European Credit Transfer and Accumulation System',
-                                        'target_framework': 'ECTS',
-                                        'target_code': '2.5',
-                                    },
-                                ],
-                                'badgeclassextension_set': [
-                                    {'name': 'extensions:LanguageExtension', 'value': 'en_EN'},
-                                    {
-                                        'name': 'extensions:LearningOutcomeExtension',
-                                        'value': 'This is an edubadge for demonstration purposes. The learning outcome for this edubadge is:\n\n* you have a basic understanding of edubadges,\n* you have a basic understanding how to use eduID.\n',
+                                        "target_name": "ECTS",
+                                        "target_url": "https://ec.europa.eu/education/resources-and-tools/european-credit-transfer-and-accumulation-system-ects_en",
+                                        "target_description": "European Credit Transfer and Accumulation System",
+                                        "target_framework": "ECTS",
+                                        "target_code": "2.5",
                                     },
                                 ],
-                                'issuer': {
-                                    'name_dutch': 'SURF Edubadges',
-                                    'name_english': 'SURF Edubadges',
-                                    'image_dutch': 'null',
-                                    'image_english': '/media/uploads/issuers/issuer_logo_ccd075bb-23cb-40b2-8780-b5a7eda9de1c.png',
-                                    'faculty': {
-                                        'name_dutch': 'SURF',
-                                        'name_english': 'SURF',
-                                        'image_dutch': 'null',
-                                        'image_english': 'null',
-                                        'on_behalf_of': 'false',
-                                        'on_behalf_of_display_name': 'null',
-                                        'on_behalf_of_url': 'null',
-                                        'institution': {
-                                            'name_dutch': 'University Voorbeeld',
-                                            'name_english': 'University Example',
-                                            'image_dutch': '/media/uploads/institution/d0273589-2c7a-4834-8c35-fef4695f176a.png',
-                                            'image_english': '/media/uploads/institution/eae5465f-98b1-4849-ac2d-47d4e1cd1252.png',
-                                            'identifier': 'university-example.org',
-                                            'alternative_identifier': 'university-example.org.tempguestidp.edubadges.nl',
-                                            'grondslag_formeel': 'gerechtvaardigd_belang',
-                                            'grondslag_informeel': 'gerechtvaardigd_belang',
+                                "badgeclassextension_set": [
+                                    {"name": "extensions:LanguageExtension", "value": "en_EN"},
+                                    {
+                                        "name": "extensions:LearningOutcomeExtension",
+                                        "value": "This is an edubadge for demonstration purposes. The learning outcome for this edubadge is:\n\n* you have a basic understanding of edubadges,\n* you have a basic understanding how to use eduID.\n",
+                                    },
+                                ],
+                                "issuer": {
+                                    "name_dutch": "SURF Edubadges",
+                                    "name_english": "SURF Edubadges",
+                                    "image_dutch": "null",
+                                    "image_english": "/media/uploads/issuers/issuer_logo_ccd075bb-23cb-40b2-8780-b5a7eda9de1c.png",
+                                    "faculty": {
+                                        "name_dutch": "SURF",
+                                        "name_english": "SURF",
+                                        "image_dutch": "null",
+                                        "image_english": "null",
+                                        "on_behalf_of": "false",
+                                        "on_behalf_of_display_name": "null",
+                                        "on_behalf_of_url": "null",
+                                        "institution": {
+                                            "name_dutch": "University Voorbeeld",
+                                            "name_english": "University Example",
+                                            "image_dutch": "/media/uploads/institution/d0273589-2c7a-4834-8c35-fef4695f176a.png",
+                                            "image_english": "/media/uploads/institution/eae5465f-98b1-4849-ac2d-47d4e1cd1252.png",
+                                            "identifier": "university-example.org",
+                                            "alternative_identifier": "university-example.org.tempguestidp.edubadges.nl",
+                                            "grondslag_formeel": "gerechtvaardigd_belang",
+                                            "grondslag_informeel": "gerechtvaardigd_belang",
                                         },
                                     },
                                 },
                             },
                         },
-                        description='Detailed information about a specific badge instance',
+                        description="Detailed information about a specific badge instance",
                         response_only=True,
                     ),
                 ],
             ),
             404: OpenApiResponse(
-                description='Badge instance not found',
+                description="Badge instance not found",
                 examples=[
                     OpenApiExample(
-                        'Not Found',
-                        value={'detail': 'Badge instance not found'},
-                        description='The requested badge instance does not exist or user does not have access',
+                        "Not Found",
+                        value={"detail": "Badge instance not found"},
+                        description="The requested badge instance does not exist or user does not have access",
                         response_only=True,
                     ),
                 ],
@@ -470,13 +462,13 @@ class BadgeInstanceDetail(APIView):
     )
     def get(self, request, entity_id, **kwargs):
         instance = (
-            BadgeInstance.objects.select_related('badgeclass')
-            .prefetch_related('badgeclass__badgeclassextension_set')
-            .prefetch_related('badgeinstanceevidence_set')
-            .prefetch_related('badgeclass__badgeclassalignment_set')
-            .select_related('badgeclass__issuer')
-            .select_related('badgeclass__issuer__faculty')
-            .select_related('badgeclass__issuer__faculty__institution')
+            BadgeInstance.objects.select_related("badgeclass")
+            .prefetch_related("badgeclass__badgeclassextension_set")
+            .prefetch_related("badgeinstanceevidence_set")
+            .prefetch_related("badgeclass__badgeclassalignment_set")
+            .select_related("badgeclass__issuer")
+            .select_related("badgeclass__issuer__faculty")
+            .select_related("badgeclass__issuer__faculty__institution")
             .filter(user=request.user)
             .filter(entity_id=entity_id)
             .get()
@@ -485,84 +477,84 @@ class BadgeInstanceDetail(APIView):
         return Response(serializer.data)
 
     @extend_schema(
-        methods=['PUT'],
-        description='Update badge instance acceptance status and public visibility',
+        methods=["PUT"],
+        description="Update badge instance acceptance status and public visibility",
         parameters=[
             OpenApiParameter(
-                name='entity_id',
+                name="entity_id",
                 type=OpenApiTypes.STR,
                 location=OpenApiParameter.PATH,
                 required=True,
-                description='entity_id of the badge instance',
+                description="entity_id of the badge instance",
             )
         ],
         request=inline_serializer(
-            name='BadgeInstanceUpdateRequest',
+            name="BadgeInstanceUpdateRequest",
             fields={
-                'acceptance': serializers.CharField(required=False, help_text='Acceptance status of the badge'),
-                'public': serializers.BooleanField(required=False, help_text='Whether the badge should be public'),
+                "acceptance": serializers.CharField(required=False, help_text="Acceptance status of the badge"),
+                "public": serializers.BooleanField(required=False, help_text="Whether the badge should be public"),
             },
         ),
         examples=[
             OpenApiExample(
-                'Update Badge Instance Request',
+                "Update Badge Instance Request",
                 value={
-                    'acceptance': 'Accepted',
-                    'public': True,
+                    "acceptance": "Accepted",
+                    "public": True,
                 },
-                description='Example request to update badge acceptance and public status',
+                description="Example request to update badge acceptance and public status",
                 request_only=True,
             ),
         ],
         responses={
             200: OpenApiResponse(
-                description='Badge instance updated successfully',
+                description="Badge instance updated successfully",
                 response=BadgeInstanceDetailSerializer,
                 examples=[
                     OpenApiExample(
-                        'Updated Badge Instance',
+                        "Updated Badge Instance",
                         value={
-                            'id': 2,
-                            'created_at': '2021-04-20T16:20:30.528668+02:00',
-                            'entity_id': 'I41eovHQReGI_SG5KM6dSQ',
-                            'issued_on': '2021-04-20T16:20:30.521307+02:00',
-                            'award_type': 'requested',
-                            'revoked': 'false',
-                            'expires_at': 'null',
-                            'acceptance': 'Accepted',
-                            'public': 'true',
-                            'badgeclass': {
-                                'id': 3,
-                                'name': 'Edubadge account complete',
-                                'entity_id': 'nwsL-dHyQpmvOOKBscsN_A',
-                                'image': '/media/uploads/badges/issuer_badgeclass_548517aa-cbab-4a7b-a971-55cdcce0e2a5.png',
-                                'description': '### Welcome to edubadges. Let your life long learning begin! ###\r\n\r\nYou are now ready to collect all your edubadges in your backpack. In your backpack you can store and manage them safely.\r\n\r\nShare them anytime you like and with whom you like.\r\n\r\nEdubadges are visual representations of your knowledge, skills and competences.',
-                                'formal': 'false',
+                            "id": 2,
+                            "created_at": "2021-04-20T16:20:30.528668+02:00",
+                            "entity_id": "I41eovHQReGI_SG5KM6dSQ",
+                            "issued_on": "2021-04-20T16:20:30.521307+02:00",
+                            "award_type": "requested",
+                            "revoked": "false",
+                            "expires_at": "null",
+                            "acceptance": "Accepted",
+                            "public": "true",
+                            "badgeclass": {
+                                "id": 3,
+                                "name": "Edubadge account complete",
+                                "entity_id": "nwsL-dHyQpmvOOKBscsN_A",
+                                "image": "/media/uploads/badges/issuer_badgeclass_548517aa-cbab-4a7b-a971-55cdcce0e2a5.png",
+                                "description": "### Welcome to edubadges. Let your life long learning begin! ###\r\n\r\nYou are now ready to collect all your edubadges in your backpack. In your backpack you can store and manage them safely.\r\n\r\nShare them anytime you like and with whom you like.\r\n\r\nEdubadges are visual representations of your knowledge, skills and competences.",
+                                "formal": "false",
                             },
                         },
-                        description='Updated badge instance details',
+                        description="Updated badge instance details",
                         response_only=True,
                     ),
                 ],
             ),
             404: OpenApiResponse(
-                description='Badge instance not found',
+                description="Badge instance not found",
                 examples=[
                     OpenApiExample(
-                        'Not Found',
-                        value={'detail': 'Badge instance not found'},
-                        description='The requested badge instance does not exist or user does not have access',
+                        "Not Found",
+                        value={"detail": "Badge instance not found"},
+                        description="The requested badge instance does not exist or user does not have access",
                         response_only=True,
                     ),
                 ],
             ),
             400: OpenApiResponse(
-                description='Invalid request data',
+                description="Invalid request data",
                 examples=[
                     OpenApiExample(
-                        'Invalid Data',
-                        value={'public': ['This field is required.']},
-                        description='Validation errors in the request data',
+                        "Invalid Data",
+                        value={"public": ["This field is required."]},
+                        description="Validation errors in the request data",
                         response_only=True,
                     ),
                 ],
@@ -572,29 +564,29 @@ class BadgeInstanceDetail(APIView):
     )
     def put(self, request, entity_id, **kwargs):
         instance = (
-            BadgeInstance.objects.select_related('badgeclass')
-            .select_related('badgeclass__issuer')
-            .select_related('badgeclass__issuer__faculty')
-            .select_related('badgeclass__issuer__faculty__institution')
+            BadgeInstance.objects.select_related("badgeclass")
+            .select_related("badgeclass__issuer")
+            .select_related("badgeclass__issuer__faculty")
+            .select_related("badgeclass__issuer__faculty__institution")
             .filter(user=request.user)
             .filter(entity_id=entity_id)
             .get()
         )
 
         # Only allow updating acceptance and public fields
-        acceptance = request.data.get('acceptance')
-        public = request.data.get('public')
+        acceptance = request.data.get("acceptance")
+        public = request.data.get("public")
 
         # Validate acceptance field if provided
         if acceptance is not None:
-            if acceptance not in ['Accepted', 'Unaccepted', 'Rejected']:
+            if acceptance not in ["Accepted", "Unaccepted", "Rejected"]:
                 return Response(
-                    {'detail': 'Invalid acceptance value. Must be one of: Accepted, Unaccepted, Rejected'},
+                    {"detail": "Invalid acceptance value. Must be one of: Accepted, Unaccepted, Rejected"},
                     status=status.HTTP_400_BAD_REQUEST,
                 )
             # Only allow changing to 'Accepted' if currently not accepted
-            if instance.acceptance in ['Unaccepted', 'Rejected'] and acceptance == 'Accepted':
-                instance.acceptance = 'Accepted'
+            if instance.acceptance in ["Unaccepted", "Rejected"] and acceptance == "Accepted":
+                instance.acceptance = "Accepted"
 
         # Update public field if provided
         if public is not None:
@@ -611,54 +603,54 @@ class UnclaimedDirectAwards(APIView):
     permission_classes = (MobileAPIPermission,)
 
     @extend_schema(
-        methods=['GET'],
-        description='Get all unclaimed awarded badges for the user',
+        methods=["GET"],
+        description="Get all unclaimed awarded badges for the user",
         responses={
             200: OpenApiResponse(
-                description='List of unclaimed direct awards',
+                description="List of unclaimed direct awards",
                 response=DirectAwardSerializer(many=True),
                 examples=[
                     OpenApiExample(
-                        'Unclaimed Direct Awards',
+                        "Unclaimed Direct Awards",
                         value=[
                             {
-                                'id': 9606,
-                                'created_at': '2026-01-23T16:19:08.699037+01:00',
-                                'entity_id': 'Lgnh9njyStmGiI_w8396Xg',
-                                'badgeclass': {
-                                    'id': 113,
-                                    'name': 'unclaimed test',
-                                    'entity_id': 'X4MQyOYPS9yoMyZwZik1Jg',
-                                    'image_url': 'https://api-demo.edubadges.nl/media/uploads/badges/issuer_badgeclass_32c9f91d-e731-40d4-99d4-c06ec6922f31.png',
-                                    'issuer': {
-                                        'name_dutch': 'SURF Edubadges',
-                                        'name_english': 'SURF Edubadges',
-                                        'image_dutch': 'null',
-                                        'image_english': '/media/uploads/issuers/issuer_logo_ccd075bb-23cb-40b2-8780-b5a7eda9de1c.png',
-                                        'faculty': {
-                                            'name_dutch': 'SURF',
-                                            'name_english': 'SURF',
-                                            'image_dutch': 'null',
-                                            'image_english': 'null',
-                                            'on_behalf_of': 'false',
-                                            'on_behalf_of_display_name': 'null',
-                                            'on_behalf_of_url': 'null',
-                                            'institution': {
-                                                'name_dutch': 'University Voorbeeld',
-                                                'name_english': 'University Example',
-                                                'image_dutch': '/media/uploads/institution/d0273589-2c7a-4834-8c35-fef4695f176a.png',
-                                                'image_english': '/media/uploads/institution/eae5465f-98b1-4849-ac2d-47d4e1cd1252.png',
-                                                'identifier': 'university-example.org',
-                                                'alternative_identifier': 'university-example.org.tempguestidp.edubadges.nl',
-                                                'grondslag_formeel': 'gerechtvaardigd_belang',
-                                                'grondslag_informeel': 'gerechtvaardigd_belang',
+                                "id": 9606,
+                                "created_at": "2026-01-23T16:19:08.699037+01:00",
+                                "entity_id": "Lgnh9njyStmGiI_w8396Xg",
+                                "badgeclass": {
+                                    "id": 113,
+                                    "name": "unclaimed test",
+                                    "entity_id": "X4MQyOYPS9yoMyZwZik1Jg",
+                                    "image_url": "https://api-demo.edubadges.nl/media/uploads/badges/issuer_badgeclass_32c9f91d-e731-40d4-99d4-c06ec6922f31.png",
+                                    "issuer": {
+                                        "name_dutch": "SURF Edubadges",
+                                        "name_english": "SURF Edubadges",
+                                        "image_dutch": "null",
+                                        "image_english": "/media/uploads/issuers/issuer_logo_ccd075bb-23cb-40b2-8780-b5a7eda9de1c.png",
+                                        "faculty": {
+                                            "name_dutch": "SURF",
+                                            "name_english": "SURF",
+                                            "image_dutch": "null",
+                                            "image_english": "null",
+                                            "on_behalf_of": "false",
+                                            "on_behalf_of_display_name": "null",
+                                            "on_behalf_of_url": "null",
+                                            "institution": {
+                                                "name_dutch": "University Voorbeeld",
+                                                "name_english": "University Example",
+                                                "image_dutch": "/media/uploads/institution/d0273589-2c7a-4834-8c35-fef4695f176a.png",
+                                                "image_english": "/media/uploads/institution/eae5465f-98b1-4849-ac2d-47d4e1cd1252.png",
+                                                "identifier": "university-example.org",
+                                                "alternative_identifier": "university-example.org.tempguestidp.edubadges.nl",
+                                                "grondslag_formeel": "gerechtvaardigd_belang",
+                                                "grondslag_informeel": "gerechtvaardigd_belang",
                                             },
                                         },
                                     },
                                 },
                             }
                         ],
-                        description='Array of unclaimed direct awards available to the user',
+                        description="Array of unclaimed direct awards available to the user",
                         response_only=True,
                     ),
                 ],
@@ -672,15 +664,15 @@ class UnclaimedDirectAwards(APIView):
         affiliations = StudentAffiliation.objects.filter(user=request.user)
 
         direct_awards = (
-            DirectAward.objects.select_related('badgeclass')
-            .select_related('badgeclass__issuer')
-            .select_related('badgeclass__issuer__faculty')
-            .select_related('badgeclass__issuer__faculty__institution')
+            DirectAward.objects.select_related("badgeclass")
+            .select_related("badgeclass__issuer")
+            .select_related("badgeclass__issuer__faculty")
+            .select_related("badgeclass__issuer__faculty__institution")
             .filter(
-                Q(eppn__in=Subquery(affiliations.values('eppn')))
+                Q(eppn__in=Subquery(affiliations.values("eppn")))
                 | Q(recipient_email=request.user.email, bundle__identifier_type=DirectAwardBundle.IDENTIFIER_EMAIL)
             )
-            .filter(status='Unaccepted')
+            .filter(status="Unaccepted")
         )
 
         serializer = DirectAwardSerializer(direct_awards, many=True)
@@ -765,13 +757,13 @@ class DirectAwardDetailView(generics.RetrieveAPIView):
     lookup_field = "entity_id"
 
     queryset = DirectAward.objects.select_related(
-        'badgeclass',
-        'badgeclass__issuer',
-        'badgeclass__issuer__faculty',
-        'badgeclass__issuer__faculty__institution',
+        "badgeclass",
+        "badgeclass__issuer",
+        "badgeclass__issuer__faculty",
+        "badgeclass__issuer__faculty__institution",
     ).prefetch_related(
-        'badgeclass__badgeclassextension_set',
-        'badgeclass__issuer__faculty__institution__terms',
+        "badgeclass__badgeclassextension_set",
+        "badgeclass__issuer__faculty__institution__terms",
     )
 
 
@@ -779,57 +771,57 @@ class Enrollments(APIView):
     permission_classes = (MobileAPIPermission,)
 
     @extend_schema(
-        methods=['GET'],
-        description='Get all enrollments for the user',
+        methods=["GET"],
+        description="Get all enrollments for the user",
         responses={
             200: OpenApiResponse(
-                description='List of enrollments',
+                description="List of enrollments",
                 response=StudentsEnrolledSerializer(many=True),
                 examples=[
                     OpenApiExample(
-                        'Enrollments List',
+                        "Enrollments List",
                         value=[
                             {
-                                'id': 40,
-                                'entity_id': 'UMcx7xCPS4yBuztOj2IDEw',
-                                'created_at': '2023-09-04T14:42:03.046498+02:00',
-                                'denied': False,
-                                'issued_on': '2023-09-04T15:02:15.088536+02:00',
-                                'acceptance': 'Unaccepted',
-                                'badgeclass': {
-                                    'id': 119,
-                                    'name': 'Test enrollment',
-                                    'entity_id': '_KI6moSxQ3mAzPEfYUHnLg',
-                                    'image': 'https://api-demo.edubadges.nl/media/uploads/badges/issuer_badgeclass_3b1a3c87-d7c6-488f-a1f9-1d3019a137ee.png',
-                                    'issuer': {
-                                        'name_dutch': 'SURF Edubadges',
-                                        'name_english': 'SURF Edubadges',
-                                        'image_dutch': None,
-                                        'image_english': '/media/uploads/issuers/issuer_logo_ccd075bb-23cb-40b2-8780-b5a7eda9de1c.png',
-                                        'faculty': {
-                                            'name_dutch': 'SURF',
-                                            'name_english': 'SURF',
-                                            'image_dutch': None,
-                                            'image_english': None,
-                                            'on_behalf_of': False,
-                                            'on_behalf_of_display_name': None,
-                                            'on_behalf_of_url': None,
-                                            'institution': {
-                                                'name_dutch': 'University Voorbeeld',
-                                                'name_english': 'University Example',
-                                                'image_dutch': '/media/uploads/institution/d0273589-2c7a-4834-8c35-fef4695f176a.png',
-                                                'image_english': '/media/uploads/institution/eae5465f-98b1-4849-ac2d-47d4e1cd1252.png',
-                                                'identifier': 'university-example.org',
-                                                'alternative_identifier': 'university-example.org.tempguestidp.edubadges.nl',
-                                                'grondslag_formeel': 'gerechtvaardigd_belang',
-                                                'grondslag_informeel': 'gerechtvaardigd_belang',
+                                "id": 40,
+                                "entity_id": "UMcx7xCPS4yBuztOj2IDEw",
+                                "created_at": "2023-09-04T14:42:03.046498+02:00",
+                                "denied": False,
+                                "issued_on": "2023-09-04T15:02:15.088536+02:00",
+                                "acceptance": "Unaccepted",
+                                "badgeclass": {
+                                    "id": 119,
+                                    "name": "Test enrollment",
+                                    "entity_id": "_KI6moSxQ3mAzPEfYUHnLg",
+                                    "image": "https://api-demo.edubadges.nl/media/uploads/badges/issuer_badgeclass_3b1a3c87-d7c6-488f-a1f9-1d3019a137ee.png",
+                                    "issuer": {
+                                        "name_dutch": "SURF Edubadges",
+                                        "name_english": "SURF Edubadges",
+                                        "image_dutch": None,
+                                        "image_english": "/media/uploads/issuers/issuer_logo_ccd075bb-23cb-40b2-8780-b5a7eda9de1c.png",
+                                        "faculty": {
+                                            "name_dutch": "SURF",
+                                            "name_english": "SURF",
+                                            "image_dutch": None,
+                                            "image_english": None,
+                                            "on_behalf_of": False,
+                                            "on_behalf_of_display_name": None,
+                                            "on_behalf_of_url": None,
+                                            "institution": {
+                                                "name_dutch": "University Voorbeeld",
+                                                "name_english": "University Example",
+                                                "image_dutch": "/media/uploads/institution/d0273589-2c7a-4834-8c35-fef4695f176a.png",
+                                                "image_english": "/media/uploads/institution/eae5465f-98b1-4849-ac2d-47d4e1cd1252.png",
+                                                "identifier": "university-example.org",
+                                                "alternative_identifier": "university-example.org.tempguestidp.edubadges.nl",
+                                                "grondslag_formeel": "gerechtvaardigd_belang",
+                                                "grondslag_informeel": "gerechtvaardigd_belang",
                                             },
                                         },
                                     },
                                 },
                             },
                         ],
-                        description='Array of course enrollments for the user',
+                        description="Array of course enrollments for the user",
                         response_only=True,
                     ),
                 ],
@@ -841,10 +833,10 @@ class Enrollments(APIView):
         # ForeignKey / OneToOneField → select_related
         # ManyToManyField / reverse FK → prefetch_related
         enrollments = (
-            StudentsEnrolled.objects.select_related('badge_class')
-            .select_related('badge_class__issuer')
-            .select_related('badge_class__issuer__faculty')
-            .select_related('badge_class__issuer__faculty__institution')
+            StudentsEnrolled.objects.select_related("badge_class")
+            .select_related("badge_class__issuer")
+            .select_related("badge_class__issuer__faculty")
+            .select_related("badge_class__issuer__faculty__institution")
             .filter(user=request.user)
         )
 
@@ -856,91 +848,86 @@ class EnrollmentDetail(APIView):
     permission_classes = (MobileAPIPermission,)
 
     @extend_schema(
-        methods=['GET'],
-        description='Get enrollment details for the user',
+        methods=["GET"],
+        description="Get enrollment details for the user",
         parameters=[
             OpenApiParameter(
-                name='entity_id',
+                name="entity_id",
                 type=OpenApiTypes.STR,
                 location=OpenApiParameter.PATH,
                 required=True,
-                description='entity_id of the enrollment',
+                description="entity_id of the enrollment",
             )
         ],
         responses={
             200: OpenApiResponse(
-                description='Enrollment details',
+                description="Enrollment details",
                 response=StudentsEnrolledDetailSerializer,
                 examples=[
                     OpenApiExample(
-                        'Enrollment Details',
+                        "Enrollment Details",
                         value={
-                            'id': 40,
-                            'entity_id': 'UMcx7xCPS4yBuztOj2IDEw',
-                            'created_at': '2023-09-04T14:42:03.046498+02:00',
-                            'denied': False,
-                            'issued_on': '2023-09-04T15:02:15.088536+02:00',
-                            'acceptance': 'Unaccepted',
-                            'badgeclass': {
-                                'id': 119,
-                                'name': 'Test enrollment',
-                                'entity_id': '_KI6moSxQ3mAzPEfYUHnLg',
-                                'image': 'https://api-demo.edubadges.nl/media/uploads/badges/issuer_badgeclass_3b1a3c87-d7c6-488f-a1f9-1d3019a137ee.png',
-                                'description': 'This is a detailed badge class description',
-                                'formal': True,
-                                'participation': 'optional',
-                                'assessment_type': 'exam',
-                                'assessment_id_verified': True,
-                                'assessment_supervised': False,
-                                'quality_assurance_name': 'QA Name',
-                                'stackable': False,
-                                'badgeclassextension_set': [
-                                    {
-                                        'name': 'ECTS',
-                                        'value': 2.5
-                                    }
-                                ],
-                                'badge_class_type': 'standard',
-                                'expiration_period': None,
-                                'issuer': {
-                                    'name_dutch': 'SURF Edubadges',
-                                    'name_english': 'SURF Edubadges',
-                                    'image_dutch': None,
-                                    'image_english': '/media/uploads/issuers/issuer_logo_ccd075bb-23cb-40b2-8780-b5a7eda9de1c.png',
-                                    'faculty': {
-                                        'name_dutch': 'SURF',
-                                        'name_english': 'SURF',
-                                        'image_dutch': None,
-                                        'image_english': None,
-                                        'on_behalf_of': False,
-                                        'on_behalf_of_display_name': None,
-                                        'on_behalf_of_url': None,
-                                        'institution': {
-                                            'name_dutch': 'University Voorbeeld',
-                                            'name_english': 'University Example',
-                                            'image_dutch': '/media/uploads/institution/d0273589-2c7a-4834-8c35-fef4695f176a.png',
-                                            'image_english': '/media/uploads/institution/eae5465f-98b1-4849-ac2d-47d4e1cd1252.png',
-                                            'identifier': 'university-example.org',
-                                            'alternative_identifier': 'university-example.org.tempguestidp.edubadges.nl',
-                                            'grondslag_formeel': 'gerechtvaardigd_belang',
-                                            'grondslag_informeel': 'gerechtvaardigd_belang',
+                            "id": 40,
+                            "entity_id": "UMcx7xCPS4yBuztOj2IDEw",
+                            "created_at": "2023-09-04T14:42:03.046498+02:00",
+                            "denied": False,
+                            "issued_on": "2023-09-04T15:02:15.088536+02:00",
+                            "acceptance": "Unaccepted",
+                            "badgeclass": {
+                                "id": 119,
+                                "name": "Test enrollment",
+                                "entity_id": "_KI6moSxQ3mAzPEfYUHnLg",
+                                "image": "https://api-demo.edubadges.nl/media/uploads/badges/issuer_badgeclass_3b1a3c87-d7c6-488f-a1f9-1d3019a137ee.png",
+                                "description": "This is a detailed badge class description",
+                                "formal": True,
+                                "participation": "optional",
+                                "assessment_type": "exam",
+                                "assessment_id_verified": True,
+                                "assessment_supervised": False,
+                                "quality_assurance_name": "QA Name",
+                                "stackable": False,
+                                "badgeclassextension_set": [{"name": "ECTS", "value": 2.5}],
+                                "badge_class_type": "standard",
+                                "expiration_period": None,
+                                "issuer": {
+                                    "name_dutch": "SURF Edubadges",
+                                    "name_english": "SURF Edubadges",
+                                    "image_dutch": None,
+                                    "image_english": "/media/uploads/issuers/issuer_logo_ccd075bb-23cb-40b2-8780-b5a7eda9de1c.png",
+                                    "faculty": {
+                                        "name_dutch": "SURF",
+                                        "name_english": "SURF",
+                                        "image_dutch": None,
+                                        "image_english": None,
+                                        "on_behalf_of": False,
+                                        "on_behalf_of_display_name": None,
+                                        "on_behalf_of_url": None,
+                                        "institution": {
+                                            "name_dutch": "University Voorbeeld",
+                                            "name_english": "University Example",
+                                            "image_dutch": "/media/uploads/institution/d0273589-2c7a-4834-8c35-fef4695f176a.png",
+                                            "image_english": "/media/uploads/institution/eae5465f-98b1-4849-ac2d-47d4e1cd1252.png",
+                                            "identifier": "university-example.org",
+                                            "alternative_identifier": "university-example.org.tempguestidp.edubadges.nl",
+                                            "grondslag_formeel": "gerechtvaardigd_belang",
+                                            "grondslag_informeel": "gerechtvaardigd_belang",
                                         },
                                     },
                                 },
                             },
                         },
-                        description='Detailed information about a specific enrollment with full badgeclass details',
+                        description="Detailed information about a specific enrollment with full badgeclass details",
                         response_only=True,
                     ),
                 ],
             ),
             404: OpenApiResponse(
-                description='Enrollment not found',
+                description="Enrollment not found",
                 examples=[
                     OpenApiExample(
-                        'Not Found',
-                        value={'detail': 'Enrollment not found'},
-                        description='The requested enrollment does not exist or user does not have access',
+                        "Not Found",
+                        value={"detail": "Enrollment not found"},
+                        description="The requested enrollment does not exist or user does not have access",
                         response_only=True,
                     ),
                 ],
@@ -952,11 +939,11 @@ class EnrollmentDetail(APIView):
     # ManyToManyField / reverse FK → prefetch_related
     def get(self, request, entity_id, **kwargs):
         enrollment = (
-            StudentsEnrolled.objects.select_related('badge_class')
-            .prefetch_related('badge_class__badgeclassextension_set')
-            .select_related('badge_class__issuer')
-            .select_related('badge_class__issuer__faculty')
-            .select_related('badge_class__issuer__faculty__institution')
+            StudentsEnrolled.objects.select_related("badge_class")
+            .prefetch_related("badge_class__badgeclassextension_set")
+            .select_related("badge_class__issuer")
+            .select_related("badge_class__issuer__faculty")
+            .select_related("badge_class__issuer__faculty__institution")
             .filter(user=request.user)
             .filter(entity_id=entity_id)
             .get()
@@ -965,47 +952,47 @@ class EnrollmentDetail(APIView):
         return Response(serializer.data)
 
     @extend_schema(
-        methods=['DELETE'],
-        description='Delete enrollment for the user',
+        methods=["DELETE"],
+        description="Delete enrollment for the user",
         parameters=[
             OpenApiParameter(
-                name='entity_id',
+                name="entity_id",
                 type=OpenApiTypes.STR,
                 location=OpenApiParameter.PATH,
                 required=True,
-                description='entity_id of the enrollment',
+                description="entity_id of the enrollment",
             )
         ],
         responses={
             204: OpenApiResponse(
-                description='Enrollment deleted successfully',
+                description="Enrollment deleted successfully",
                 examples=[
                     OpenApiExample(
-                        'Deleted',
+                        "Deleted",
                         value=None,
-                        description='Enrollment was successfully deleted',
+                        description="Enrollment was successfully deleted",
                         response_only=True,
                     ),
                 ],
             ),
             404: OpenApiResponse(
-                description='Enrollment not found',
+                description="Enrollment not found",
                 examples=[
                     OpenApiExample(
-                        'Not Found',
-                        value={'detail': 'Enrollment not found'},
-                        description='The requested enrollment does not exist',
+                        "Not Found",
+                        value={"detail": "Enrollment not found"},
+                        description="The requested enrollment does not exist",
                         response_only=True,
                     ),
                 ],
             ),
             400: OpenApiResponse(
-                description='Cannot delete awarded enrollment',
+                description="Cannot delete awarded enrollment",
                 examples=[
                     OpenApiExample(
-                        'Awarded Enrollment',
-                        value={'detail': 'Awarded enrollments cannot be withdrawn'},
-                        description='Cannot delete an enrollment that has already been awarded',
+                        "Awarded Enrollment",
+                        value={"detail": "Awarded enrollments cannot be withdrawn"},
+                        description="Cannot delete an enrollment that has already been awarded",
                         response_only=True,
                     ),
                 ],
@@ -1016,7 +1003,7 @@ class EnrollmentDetail(APIView):
     def delete(self, request, entity_id, **kwargs):
         enrollment = get_object_or_404(StudentsEnrolled, user=request.user, entity_id=entity_id)
         if enrollment.date_awarded:
-            raise BadgrApiException400('Awarded enrollments cannot be withdrawn', 206)
+            raise BadgrApiException400("Awarded enrollments cannot be withdrawn", 206)
         enrollment.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
 
@@ -1035,11 +1022,7 @@ class BadgeCollectionViewSet(viewsets.ModelViewSet):
     lookup_field = "entity_id"
 
     def get_queryset(self):
-        return (
-            BadgeInstanceCollection.objects
-            .filter(user=self.request.user)
-            .prefetch_related("badge_instances")
-        )
+        return BadgeInstanceCollection.objects.filter(user=self.request.user).prefetch_related("badge_instances")
 
 
 class CatalogBadgeClassListView(generics.ListAPIView):
@@ -1050,73 +1033,73 @@ class CatalogBadgeClassListView(generics.ListAPIView):
     pagination_class = CatalogPagination
 
     @extend_schema(
-        methods=['GET'],
+        methods=["GET"],
         filters=True,
-        description='Get a paginated list of badge classes. Supports filtering and page_size.',
+        description="Get a paginated list of badge classes. Supports filtering and page_size.",
         parameters=[
             OpenApiParameter(
-                name='page',
+                name="page",
                 type=OpenApiTypes.INT,
-                location='query',
+                location="query",
                 required=False,
-                description='Page number for pagination',
+                description="Page number for pagination",
             ),
             OpenApiParameter(
-                name='page_size',
+                name="page_size",
                 type=OpenApiTypes.INT,
-                location='query',
+                location="query",
                 required=False,
-                description='Number of items per page',
+                description="Number of items per page",
             ),
             OpenApiParameter(
-                name='name',
+                name="name",
                 type=OpenApiTypes.STR,
-                location='query',
+                location="query",
                 required=False,
-                description='Filter badge classes by name',
+                description="Filter badge classes by name",
             ),
             OpenApiParameter(
-                name='institution',
+                name="institution",
                 type=OpenApiTypes.STR,
-                location='query',
+                location="query",
                 required=False,
-                description='Filter badge classes by institution entity_id',
+                description="Filter badge classes by institution entity_id",
             ),
             OpenApiParameter(
-                name='institution_type',
-                location='query',
+                name="institution_type",
+                location="query",
                 required=False,
-                description='Filter badge classes by institution_type (MBO/HBO/WO)',
+                description="Filter badge classes by institution_type (MBO/HBO/WO)",
             ),
         ],
         responses={
             200: OpenApiResponse(
-                description='Paginated list of badge classes',
+                description="Paginated list of badge classes",
                 response=CatalogBadgeClassSerializer(many=True),
             ),
-            500: OpenApiResponse(description='Internal server error occurred while retrieving badge classes.'),
+            500: OpenApiResponse(description="Internal server error occurred while retrieving badge classes."),
         },
     )
     def get_queryset(self):
         return (
             BadgeClass.objects.select_related(
-                'issuer',
-                'issuer__faculty',
-                'issuer__faculty__institution',
+                "issuer",
+                "issuer__faculty",
+                "issuer__faculty__institution",
             )
             .filter(
                 is_private=False,
                 issuer__archived=False,
                 issuer__faculty__archived=False,
             )
-            .exclude(issuer__faculty__visibility_type='TEST')
-            .order_by('name')
+            .exclude(issuer__faculty__visibility_type="TEST")
+            .order_by("name")
         )
 
 
 class UserProfileView(APIView):
     permission_classes = (IsAuthenticated, MobileAPIPermission)
-    http_method_names = ('get', 'delete')
+    http_method_names = ("get", "delete")
 
     @extend_schema(
         description="Get the authenticated user's profile",
@@ -1125,15 +1108,15 @@ class UserProfileView(APIView):
     def get(self, request):
         serializer = UserProfileSerializer(
             request.user,
-            context={'request': request},
+            context={"request": request},
         )
         return Response(serializer.data)
 
     @extend_schema(
-        description='Delete the authenticated user',
+        description="Delete the authenticated user",
         responses={
-            204: OpenApiResponse(description='User account deleted successfully'),
-            403: OpenApiResponse(description='Permission denied'),
+            204: OpenApiResponse(description="User account deleted successfully"),
+            403: OpenApiResponse(description="Permission denied"),
         },
     )
     def delete(self, request):
@@ -1143,17 +1126,17 @@ class UserProfileView(APIView):
 
 class BadgeClassDetailView(generics.RetrieveAPIView):
     permission_classes = (IsAuthenticated, MobileAPIPermission)
-    lookup_field = 'entity_id'
+    lookup_field = "entity_id"
     serializer_class = BadgeClassDetailSerializer
     queryset = BadgeClass.objects.select_related(
-        'issuer',
-        'issuer__faculty',
-        'issuer__faculty__institution',
+        "issuer",
+        "issuer__faculty",
+        "issuer__faculty__institution",
     ).prefetch_related(
-        'badgeclassextension_set',
-        'badgeclassalignment_set',
-        'issuer__faculty__institution__terms',
-        'issuer__faculty__institution__terms__terms_urls',
+        "badgeclassextension_set",
+        "badgeclassalignment_set",
+        "issuer__faculty__institution__terms",
+        "issuer__faculty__institution__terms__terms_urls",
     )
 
 
@@ -1162,20 +1145,24 @@ class InstitutionListView(ListAPIView):
     serializer_class = InstitutionListSerializer
 
     def get_queryset(self):
-        institution_entity_ids = BadgeClass.objects.select_related(
-            'issuer',
-            'issuer__faculty',
-            'issuer__faculty__institution',
-        ).filter(
-            is_private=False,
-            issuer__archived=False,
-            issuer__faculty__archived=False,
-        ).exclude(
-            issuer__faculty__visibility_type='TEST'
-        ).values_list(
-            'issuer__faculty__institution__entity_id',
-            flat=True,
-        ).distinct()
+        institution_entity_ids = (
+            BadgeClass.objects.select_related(
+                "issuer",
+                "issuer__faculty",
+                "issuer__faculty__institution",
+            )
+            .filter(
+                is_private=False,
+                issuer__archived=False,
+                issuer__faculty__archived=False,
+            )
+            .exclude(issuer__faculty__visibility_type="TEST")
+            .values_list(
+                "issuer__faculty__institution__entity_id",
+                flat=True,
+            )
+            .distinct()
+        )
         return Institution.objects.filter(entity_id__in=institution_entity_ids)
 
 
@@ -1193,16 +1180,16 @@ class InstitutionListView(ListAPIView):
         request=FCMDeviceSerializer,
         examples=[
             OpenApiExample(
-                'Example Device Registration',
-                summary='Example payload to register or update a device',
+                "Example Device Registration",
+                summary="Example payload to register or update a device",
                 value={
-                    'registration_id': 'fcm-token-123456',
-                    'type': 'ios',
-                    'name': "John's iPhone",
-                    'device_id': 'abc123...',
-                    'active': True,
+                    "registration_id": "fcm-token-123456",
+                    "type": "ios",
+                    "name": "John's iPhone",
+                    "device_id": "abc123...",
+                    "active": True,
                 },
-                request_only=True
+                request_only=True,
             )
         ],
     ),
@@ -1211,14 +1198,14 @@ class InstitutionListView(ListAPIView):
         request=FCMDeviceSerializer,
         examples=[
             OpenApiExample(
-                'Example Device Registration',
+                "Example Device Registration",
                 value={
-                    'id': 5,
-                    'registration_id': 'fcm-token-123456',
-                    'type': 'ios',
-                    'name': "John's iPhone",
-                    'device_id': 'abc123...',
-                    'active': True,
+                    "id": 5,
+                    "registration_id": "fcm-token-123456",
+                    "type": "ios",
+                    "name": "John's iPhone",
+                    "device_id": "abc123...",
+                    "active": True,
                 },
             )
         ],
@@ -1231,16 +1218,16 @@ class RegisterDeviceViewSet(FCMDeviceAuthorizedViewSet):
 class TermsAgreementViewSet(viewsets.ModelViewSet):
     queryset = TermsAgreement.objects.all()
     permission_classes = (IsAuthenticated, MobileAPIPermission)
-    http_method_names = ('get', 'post', 'patch')
-    lookup_field = 'entity_id'
+    http_method_names = ("get", "post", "patch")
+    lookup_field = "entity_id"
 
     def get_queryset(self):
         return TermsAgreement.objects.filter(user=self.request.user, terms__institution__isnull=False)
 
     def get_serializer_class(self):
-        if self.action == 'create':
+        if self.action == "create":
             return TermsAgreementCreateSerializer
-        elif self.action == 'partial_update':
+        elif self.action == "partial_update":
             return TermsAgreementUpdateSerializer
         else:
             return TermsAgreementSerializer

--- a/apps/mobile_api/serializers.py
+++ b/apps/mobile_api/serializers.py
@@ -580,6 +580,10 @@ class CatalogBadgeClassSerializer(serializers.ModelSerializer):
     institution_image_english = serializers.CharField(source='issuer.faculty.institution.image_english', read_only=True)
     institution_type = serializers.CharField(source='issuer.faculty.institution.institution_type', read_only=True)
 
+    # Necessary for backward compatibility with the mobile app
+    self_requested_assertions_count = serializers.SerializerMethodField()
+    direct_awarded_assertions_count = serializers.SerializerMethodField()
+
     class Meta:
         model = BadgeClass
         fields = [
@@ -609,4 +613,16 @@ class CatalogBadgeClassSerializer(serializers.ModelSerializer):
             'institution_image_dutch',
             'institution_image_english',
             'institution_type',
+            'self_requested_assertions_count',
+            'direct_awarded_assertions_count',
         ]
+
+    @staticmethod
+    def get_self_requested_assertions_count(obj):
+        # Necessary for backward compatibility with the mobile app
+        return 0
+
+    @staticmethod
+    def get_direct_awarded_assertions_count(obj):
+        # Necessary for backward compatibility with the mobile app
+        return 0

--- a/apps/mobile_api/serializers.py
+++ b/apps/mobile_api/serializers.py
@@ -104,6 +104,8 @@ class BadgeClassDetailSerializer(serializers.ModelSerializer):
     badgeclassextension_set = BadgeClassExtensionSerializer(many=True, read_only=True)
     self_enrollment_enabled = serializers.SerializerMethodField()
     user_may_enroll = serializers.SerializerMethodField()
+    required_terms = serializers.SerializerMethodField()
+    user_has_accepted_terms = serializers.SerializerMethodField()
     alignments = BadgeClassAlignmentSerializer(
         source='badgeclassalignment_set',
         many=True,
@@ -132,6 +134,8 @@ class BadgeClassDetailSerializer(serializers.ModelSerializer):
             'criteria_text',
             'self_enrollment_enabled',
             'user_may_enroll',
+            'required_terms',
+            'user_has_accepted_terms',
             'eqf_nlqf_level_verified',
             'alignments',
             'badgeclassextension_set',
@@ -149,6 +153,20 @@ class BadgeClassDetailSerializer(serializers.ModelSerializer):
             return False
         user = request.user
         return obj.user_may_enroll(user)
+
+    def get_required_terms(self, obj):
+        try:
+            terms = obj.get_required_terms()
+        except ValueError:
+            return None
+
+        return TermsSerializer(terms, context=self.context).data
+
+    def get_user_has_accepted_terms(self, obj):
+        request = self.context.get("request")
+        if not request or not request.user.is_authenticated:
+            return False
+        return obj.terms_accepted(request.user)
 
 
 class BadgeInstanceSerializer(serializers.ModelSerializer):
@@ -537,10 +555,6 @@ class CatalogBadgeClassSerializer(serializers.ModelSerializer):
     is_private = serializers.BooleanField()
     is_micro_credentials = serializers.BooleanField()
     badge_class_type = serializers.CharField()
-    required_terms = serializers.SerializerMethodField()
-    user_has_accepted_terms = serializers.SerializerMethodField()
-    self_enrollment_enabled = serializers.SerializerMethodField()
-    user_may_enroll = serializers.SerializerMethodField()
 
     # Issuer fields
     issuer_name_english = serializers.CharField(source='issuer.name_english', read_only=True)
@@ -566,14 +580,9 @@ class CatalogBadgeClassSerializer(serializers.ModelSerializer):
     institution_image_english = serializers.CharField(source='issuer.faculty.institution.image_english', read_only=True)
     institution_type = serializers.CharField(source='issuer.faculty.institution.institution_type', read_only=True)
 
-    # Annotated counts
-    self_requested_assertions_count = serializers.IntegerField(read_only=True)
-    direct_awarded_assertions_count = serializers.IntegerField(read_only=True)
-
     class Meta:
         model = BadgeClass
         fields = [
-            # BadgeClass
             'created_at',
             'name',
             'image',
@@ -582,19 +591,11 @@ class CatalogBadgeClassSerializer(serializers.ModelSerializer):
             'is_private',
             'is_micro_credentials',
             'badge_class_type',
-            'required_terms',
-            'user_has_accepted_terms',
-            'self_enrollment_enabled',
-            'user_may_enroll',
-
-            # Issuer
             'issuer_name_english',
             'issuer_name_dutch',
             'issuer_entity_id',
             'issuer_image_dutch',
             'issuer_image_english',
-
-            # Faculty
             'faculty_name_english',
             'faculty_name_dutch',
             'faculty_entity_id',
@@ -602,44 +603,10 @@ class CatalogBadgeClassSerializer(serializers.ModelSerializer):
             'faculty_image_english',
             'faculty_on_behalf_of',
             'faculty_type',
-
-            # Institution
             'institution_name_english',
             'institution_name_dutch',
             'institution_entity_id',
             'institution_image_dutch',
             'institution_image_english',
             'institution_type',
-
-            # Counts
-            'self_requested_assertions_count',
-            'direct_awarded_assertions_count'
         ]
-
-    def get_required_terms(self, obj):
-        try:
-            terms = obj.get_required_terms()
-        except ValueError:
-            return None  # Should not break the serializer
-
-        return TermsSerializer(terms, context=self.context).data
-
-    def get_user_has_accepted_terms(self, obj):
-        request = self.context.get("request")
-        if not request or not request.user.is_authenticated:
-            return False
-
-        user = request.user
-        return obj.terms_accepted(user)
-
-    @extend_schema_field(serializers.BooleanField)
-    def get_self_enrollment_enabled(self, obj):
-        return not obj.self_enrollment_disabled
-
-    @extend_schema_field(serializers.BooleanField)
-    def get_user_may_enroll(self, obj):
-        request = self.context.get("request")
-        if not request or not request.user.is_authenticated:
-            return False
-        user = request.user
-        return obj.user_may_enroll(user)


### PR DESCRIPTION
Changes made:
- CatalogBadgeClassSerializer: remove required_terms, user_has_accepted_terms, user_may_enroll, self_requested_assertions_count, direct_awarded_assertions_count (not used in the list view)
- CatalogBadgeClassListView: remove COUNT() annotations and terms prefetch from queryset (saves 2x COUNT queries per page + unnecessary prefetch)
- BadgeClassDetailSerializer: add required_terms and user_has_accepted_terms so the detail endpoint has all user-specific info the mobile app needs after a user taps a badge
- BadgeClassDetailView: prefetch institution__terms/terms_urls to avoid N+1 on get_required_terms()
- Clean up unused Count import