### PR TITLE
EB-13 Add recipient info to serializer for direct award detail info

### DIFF
--- a/apps/mobile_api/serializers.py
+++ b/apps/mobile_api/serializers.py
@@ -277,6 +277,10 @@ class DirectAwardDetailSerializer(serializers.ModelSerializer):
             'required_terms',
             'user_has_accepted_terms',
             'grade_achieved',
+            'eppn',
+            'recipient_email',
+            'recipient_first_name',
+            'recipient_surname',
         ]
 
     def get_required_terms(self, obj):


### PR DESCRIPTION
These fields are needed in order for the mobile app to show the recipient name in the claim popup.